### PR TITLE
char (*)[] -> char ** for clang compatibility

### DIFF
--- a/src/env/inline_mem.h
+++ b/src/env/inline_mem.h
@@ -18,15 +18,15 @@ __attribute__((__always_inline__)) static inline void * _MCFCRT_inline_mempcpy_f
 	if(__builtin_constant_p(__n) ? (__n / 8) : true){
 		__asm__ (
 			"rep movsq \n"
-			: "=o"(*(char (*)[])__p1), "+D"(__p1), "+S"(__p2), "=c"(__dumb)
-			: "o"(*(const char (*)[])__p2), "c"(__n / 8)
+			: "=o"(*(char **)__p1), "+D"(__p1), "+S"(__p2), "=c"(__dumb)
+			: "o"(*(const char **)__p2), "c"(__n / 8)
 		);
 	}
 	if(__builtin_constant_p(__n) ? (__n % 8) : true){
 		__asm__ (
 			"rep movsb \n"
 			: "=o"(*(char (*)[])__p1), "+D"(__p1), "+S"(__p2), "=c"(__dumb)
-			: "o"(*(const char (*)[])__p2), "c"(__n % 8)
+			: "o"(*(const char **)__p2), "c"(__n % 8)
 		);
 	}
 #else


### PR DESCRIPTION
Otherwise,
error: dereference of pointer to incomplete type 'const char []'