### PR TITLE
Use SEH in `*_once()`

### DIFF
--- a/mcfgthread/c11.h
+++ b/mcfgthread/c11.h
@@ -425,24 +425,7 @@ __MCF_C11_INLINE
 void
 __MCF_c11_call_once(once_flag* __once, __MCF_once_callback* __init_proc)
   {
-#ifdef _MSC_VER
-    _MCF_once* __once_g = __MCF_nullptr;
-    __try
-#else
-    _MCF_once* __once_g __attribute__((__cleanup__(__MCF_gthr_unonce))) = __MCF_nullptr;
-#endif
-    {
-      if(_MCF_once_wait(__once, __MCF_nullptr) == 0)
-        return;
-
-      __once_g = __once;
-      __init_proc();
-      __once_g = __MCF_nullptr;
-      _MCF_once_release(__once);
-    }
-#ifdef _MSC_VER
-    __finally { __MCF_gthr_unonce(&__once_g);  }
-#endif
+    __MCF_gthr_call_once_seh(__once, (__MCF_cxa_dtor_cdecl*)(intptr_t) __init_proc, __MCF_nullptr);
   }
 
 __MCF_C11_INLINE

--- a/mcfgthread/gthr.h
+++ b/mcfgthread/gthr.h
@@ -345,25 +345,8 @@ __MCF_GTHR_INLINE
 int
 __MCF_gthr_once(__gthread_once_t* __once, __MCF_once_callback* __init_proc)
   {
-#ifdef _MSC_VER
-    _MCF_once* __once_g = __MCF_nullptr;
-    __try
-#else
-    _MCF_once* __once_g __attribute__((__cleanup__(__MCF_gthr_unonce))) = __MCF_nullptr;
-#endif
-    {
-      if(_MCF_once_wait(__once, __MCF_nullptr) == 0)
-        return 0;
-
-      __once_g = __once;
-      __init_proc();
-      __once_g = __MCF_nullptr;
-      _MCF_once_release(__once);
-      return 0;
-    }
-#ifdef _MSC_VER
-    __finally { __MCF_gthr_unonce(&__once_g);  }
-#endif
+    __MCF_gthr_call_once_seh(__once, (__MCF_cxa_dtor_cdecl*)(intptr_t) __init_proc, __MCF_nullptr);
+    return 0;
   }
 
 __MCF_GTHR_INLINE

--- a/mcfgthread/gthr_aux.c
+++ b/mcfgthread/gthr_aux.c
@@ -6,6 +6,173 @@
 #define __MCF_GTHR_AUX_IMPORT  __MCF_DLLEXPORT
 #define __MCF_GTHR_AUX_INLINE  __MCF_DLLEXPORT
 #include "gthr_aux.h"
+#include "xglobals.h"
+
+void
+__cdecl
+do_call_once_seh_take_over(_MCF_once* once, __MCF_cxa_dtor_cdecl* init_proc, void* arg);
+
+__asm__ (
+".text  \n\t"
+#if defined __i386__ || defined __amd64__
+/* This is required by Clang, where `-masm=intel` doesn't affect basic asm.  */
+".intel_syntax noprefix  \n\t"
+#endif
+#if defined __i386__
+/* On x86, SEH is stack-based.  */
+".def _do_call_once_seh_take_over; .scl 2; .type 32; .endef        \n\t"
+"_do_call_once_seh_take_over:                                      \n\t"
+/* The stack is used as follows:
+ *
+ * ESP  0: argument to subroutines
+ *      4: unused
+ *      8: unused
+ *     12: unused
+ *     16: establisher frame; pointer to previous frame
+ *     20: `do_call_once_seh_uhandler`
+ *     24: saved frame pointer
+ * ENT 28: return address
+ *     32: `once`
+ *     36: `init_proc`
+ *     40: `arg`
+ */
+#  define __MCF_SEH_ONCE_PTR_DISPLACEMENT   16
+"  push ebp                                                        \n\t"
+"  mov ebp, esp                                                    \n\t"
+"  sub esp, 24                                                     \n\t"
+/* Install an SEH handler.  */
+"  mov eax, DWORD PTR fs:[0]                                       \n\t"
+"  lea ecx, DWORD PTR [esp + 16]                                   \n\t"
+"  mov DWORD PTR [ecx], eax                                        \n\t"
+"  mov DWORD PTR [ecx + 4], OFFSET _do_call_once_seh_uhandler      \n\t"
+"  mov DWORD PTR fs:[0], ecx                                       \n\t"
+/* Make the call `(*init_proc) (arg)`.  */
+"  mov eax, DWORD PTR [esp + 36]                                   \n\t"
+"  mov ecx, DWORD PTR [esp + 40]                                   \n\t"
+"  mov DWORD PTR [esp], ecx                                        \n\t"
+"  call eax                                                        \n\t"
+/* Dismantle the SEH handler.  */
+"  mov ecx, DWORD PTR [esp + 16]                                   \n\t"
+"  mov DWORD PTR fs:[0], ecx                                       \n\t"
+/* Disarm the once flag with a tail call.  */
+"  leave                                                           \n\t"
+"  jmp __MCF_once_release                                          \n\t"
+#else
+/* Otherwise, SEH is table-based.  */
+".def do_call_once_seh_take_over; .scl 2; .type 32; .endef         \n\t"
+"do_call_once_seh_take_over:                                       \n\t"
+".seh_proc do_call_once_seh_take_over                              \n\t"
+".seh_handler do_call_once_seh_uhandler, " __MCF_SEH_FLAG_BOTH "   \n\t"
+#  if defined __amd64__
+/* The stack is used as follows:
+ *
+ * RSP  0: establisher frame; shallow slot for subroutines
+ *      8: ditto
+ *     16: ditto
+ *     24: ditto
+ *     32: saved frame pointer
+ * ENT 40: return address
+ *     48: shallow slot for `once` from RCX
+ *     56: shallow slot for `init_proc` from RDX
+ *     64: shallow slot for `arg` from R8
+ *     72: unused
+ */
+#  define __MCF_SEH_ONCE_PTR_DISPLACEMENT   48
+"  push rbp                                                        \n\t"
+".seh_pushreg rbp                                                  \n\t"
+"  mov rbp, rsp                                                    \n\t"
+"  sub rsp, 32                                                     \n\t"
+".seh_stackalloc 32                                                \n\t"
+".seh_endprologue                                                  \n\t"
+/* Stash `once` for the handler.  */
+"  mov QWORD PTR [rsp + 48], rcx                                   \n\t"
+/* Make the call `(*init_proc) (arg)`.  */
+"  mov rcx, r8                                                     \n\t"
+"  call rdx                                                        \n\t"
+/* Disarm the once flag with a tail call.  */
+"  mov rcx, QWORD PTR [rsp + 48]                                   \n\t"
+"  leave                                                           \n\t"
+"  jmp _MCF_once_release                                           \n\t"
+#  elif defined __arm__
+/* The stack is used as follows:
+ *
+ *  SP  0: `once` from R0
+ *      4: unused
+ *      8: saved R11
+ *     12: saved LR
+ * ENT 16: establisher frame
+ */
+#  define __MCF_SEH_ONCE_PTR_DISPLACEMENT   -16
+".thumb_func                                                       \n\t"
+"  push.w {r0, r1, r11, lr}                                        \n\t"
+".seh_save_regs_w {r0, r1, r11, lr}                                \n\t"
+"  add.w r11, sp, #8                                               \n\t"
+".seh_nop_w                                                        \n\t"
+".seh_endprologue                                                  \n\t"
+/* Make the call `(*init_proc) (arg)`.  */
+"  mov.w r0, r2                                                    \n\t"
+"  blx r1                                                          \n\t"
+/* Disarm the once flag with a tail call.  */
+".seh_startepilogue                                                \n\t"
+"  pop.w {r0, r1, r11, lr}                                         \n\t"
+".seh_save_regs_w {r0, r1, r11, lr}                                \n\t"
+".seh_endepilogue                                                  \n\t"
+"  b.w _MCF_once_release                                           \n\t"
+#  elif defined __aarch64__
+/* The stack is used as follows:
+ *
+ *  SP  0: saved FP
+ *      8: saved LR
+ *     16: `once` from X0
+ *     24: unused
+ * ENT 32: establisher frame
+ */
+#  define __MCF_SEH_ONCE_PTR_DISPLACEMENT   -16
+"  stp fp, lr, [sp, #-32]!                                         \n\t"
+".seh_save_fplr_x 32                                               \n\t"
+"  mov fp, sp                                                      \n\t"
+".seh_set_fp                                                       \n\t"
+".seh_endprologue                                                  \n\t"
+/* Stash `once` for the handler.  */
+"  str x0, [sp, #16]                                               \n\t"
+/* Make the call `(*init_proc) (arg)`.  */
+"  mov x0, x2                                                      \n\t"
+"  blr x1                                                          \n\t"
+/* Disarm the once flag with a tail call.  */
+"  ldr x0, [sp, #16]                                               \n\t"
+".seh_startepilogue                                                \n\t"
+"  ldp fp, lr, [sp], #32                                           \n\t"
+".seh_save_fplr_x 32                                               \n\t"
+".seh_endepilogue                                                  \n\t"
+"  b _MCF_once_release                                             \n\t"
+#  endif
+".seh_endproc                                                      \n\t"
+#endif
+);
+
+static __attribute__((__used__, __unused__))  /* this must be good code!  */
+EXCEPTION_DISPOSITION
+__cdecl
+do_call_once_seh_uhandler(EXCEPTION_RECORD* rec, PVOID estab_frame, CONTEXT* ctx, PVOID disp_ctx)
+  {
+    (void) rec;
+    (void) ctx;
+    (void) disp_ctx;
+
+    /* If we are unwinding the stack, restore the once flag.  */
+    if(rec->ExceptionFlags & EXCEPTION_UNWINDING)
+      _MCF_once_abort(*(void**) ((char*) estab_frame + __MCF_SEH_ONCE_PTR_DISPLACEMENT));
+
+    /* Continue unwinding.  */
+    return ExceptionContinueSearch;
+  }
+
+__MCF_DLLEXPORT
+void
+__MCF_gthr_call_once_seh_take_over(_MCF_once* once, __MCF_cxa_dtor_cdecl* init_proc, void* arg)
+  {
+    do_call_once_seh_take_over(once, init_proc, arg);
+  }
 
 __MCF_DLLEXPORT
 int64_t

--- a/mcfgthread/libcxx.h
+++ b/mcfgthread/libcxx.h
@@ -341,25 +341,8 @@ __MCF_LIBCXX_INLINE
 int
 __MCF_libcxx_execute_once(__libcpp_exec_once_flag* __once, __MCF_once_callback* __init_proc)
   {
-#ifdef _MSC_VER
-    _MCF_once* __once_g = __MCF_nullptr;
-    __try
-#else
-    _MCF_once* __once_g __attribute__((__cleanup__(__MCF_gthr_unonce))) = __MCF_nullptr;
-#endif
-    {
-      if(_MCF_once_wait(__once, __MCF_nullptr) == 0)
-        return 0;
-
-      __once_g = __once;
-      __init_proc();
-      __once_g = __MCF_nullptr;
-      _MCF_once_release(__once);
-      return 0;
-    }
-#ifdef _MSC_VER
-    __finally { __MCF_gthr_unonce(&__once_g);  }
-#endif
+    __MCF_gthr_call_once_seh(__once, (__MCF_cxa_dtor_cdecl*)(intptr_t) __init_proc, __MCF_nullptr);
+    return 0;
   }
 
 __MCF_LIBCXX_INLINE

--- a/mcfgthread/xglobals.h
+++ b/mcfgthread/xglobals.h
@@ -161,14 +161,15 @@ __MCF_invoke_cxa_dtor(__MCF_cxa_dtor_union __dtor, void* __arg)
 #else
 /* Otherwise, SEH is table-based.  */
 #  ifdef __arm__
-#    define __MCF_SEH_FLAG_PREFIX   "%"
+#    define __MCF_SEH_FLAG_EXCEPT   "%except"
+#    define __MCF_SEH_FLAG_BOTH     "%except, %unwind"
 #  else
-#    define __MCF_SEH_FLAG_PREFIX   "@"
+#    define __MCF_SEH_FLAG_EXCEPT   "@except"
+#    define __MCF_SEH_FLAG_BOTH     "@except, @unwind"
 #  endif
 
 #  define __MCF_SEH_DEFINE_TERMINATE_FILTER  \
-    __asm__ volatile (".seh_handler "  \
-        " __MCF_seh_top, " __MCF_SEH_FLAG_PREFIX "except")  /* no semicolon  */
+    __asm__ (".seh_handler __MCF_seh_top, " __MCF_SEH_FLAG_EXCEPT)  /* no semicolon  */
 
 /* This works on x86_64, and should work on ARM (FIXME: untested).  */
 __MCF_ALWAYS_INLINE

--- a/meson.build
+++ b/meson.build
@@ -188,6 +188,8 @@ test_src = [
   'test/condition_variable_wait_for.cpp',
   'test/call_once_returning.cpp',
   'test/call_once_exceptional.cpp',
+  'test/call_once_seh_returning.cpp',
+  'test/call_once_seh_exceptional.cpp',
   'test/recursive_mutex.cpp',
   'test/recursive_mutex_try_lock.cpp',
   'test/recursive_timed_mutex_try_lock_until.cpp',

--- a/test/call_once_seh_exceptional.cpp
+++ b/test/call_once_seh_exceptional.cpp
@@ -1,0 +1,73 @@
+/* This file is part of MCF Gthread.
+ * See LICENSE.TXT for licensing information.
+ * Copyleft 2022 - 2024, LH_Mouse. All wrongs reserved.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+#include <vector>
+
+#ifdef TEST_STD
+#  include <mutex>
+#  include <thread>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+constexpr std::size_t NTHREADS = 64U;
+static std::vector<NS::thread> threads(NTHREADS);
+static _MCF_once once;
+static ::_MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+once_do_it(int add)
+  {
+    /* Perform initialization.  */
+    int old = resource;
+    NS::this_thread::sleep_for(NS::chrono::milliseconds(20));
+    resource = old + add;
+
+    NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+    throw 42;
+  }
+
+static
+void
+thread_proc()
+  {
+    ::_MCF_sem_wait(&start, nullptr);
+
+    try {
+      ::__MCF_gthr_call_once_seh(&once, (void (*)(void*))(intptr_t) once_do_it, (void*) 1);
+
+      ::std::terminate();
+    }
+    catch(int) {
+      ::printf("thread %d done\n", (int) ::_MCF_thread_self_tid());
+    }
+
+    ::printf("thread %d quitting\n", (int) ::_MCF_thread_self_tid());
+  }
+
+int
+main(void)
+  {
+#if !defined __SEH__
+    return 77;  // not supported
+#endif
+
+    for(auto& thr : threads)
+      thr = NS::thread(thread_proc);
+
+    ::printf("main waiting\n");
+    ::_MCF_sem_signal_some(&start, NTHREADS);
+
+    for(auto& thr : threads)
+      thr.join();
+
+    assert(resource == NTHREADS);
+  }

--- a/test/call_once_seh_returning.cpp
+++ b/test/call_once_seh_returning.cpp
@@ -1,0 +1,62 @@
+/* This file is part of MCF Gthread.
+ * See LICENSE.TXT for licensing information.
+ * Copyleft 2022 - 2024, LH_Mouse. All wrongs reserved.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+#include <vector>
+
+#ifdef TEST_STD
+#  include <mutex>
+#  include <thread>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+constexpr std::size_t NTHREADS = 64U;
+static std::vector<NS::thread> threads(NTHREADS);
+static _MCF_once once;
+static ::_MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+once_do_it(int add)
+  {
+    /* Perform initialization.  */
+    int old = resource;
+    NS::this_thread::sleep_for(NS::chrono::milliseconds(200));
+    resource = old + add;
+
+    NS::this_thread::sleep_for(NS::chrono::milliseconds(100));
+  }
+
+static
+void
+thread_proc()
+  {
+    ::_MCF_sem_wait(&start, nullptr);
+
+    ::__MCF_gthr_call_once_seh(&once, (void (*)(void*))(intptr_t) once_do_it, (void*) 1);
+    ::printf("thread %d done\n", (int) ::_MCF_thread_self_tid());
+
+    ::printf("thread %d quitting\n", (int) ::_MCF_thread_self_tid());
+  }
+
+int
+main(void)
+  {
+    for(auto& thr : threads)
+      thr = NS::thread(thread_proc);
+
+    ::printf("main waiting\n");
+    ::_MCF_sem_signal_some(&start, NTHREADS);
+
+    for(auto& thr : threads)
+      thr.join();
+
+    assert(resource == 1);
+  }


### PR DESCRIPTION
1. Unify all variants.
2. Allow `__gthread_once()` etc. work with MSVC.
