### PR TITLE
xglobals: Drop ARM32

### DIFF
--- a/mcfgthread/gthr_aux.c
+++ b/mcfgthread/gthr_aux.c
@@ -93,31 +93,6 @@ __asm__ (
 "  mov rcx, QWORD PTR [rbp + 16]                                   \n\t"
 "  leave                                                           \n\t"
 "  jmp _MCF_once_release                                           \n\t"
-#  elif defined __arm__
-/* The stack is used as follows:
- *
- *  SP  0: `once` from R0
- *      4: unused
- *      8: saved R11
- *     12: saved LR
- * ENT 16: establisher frame
- */
-#  define __MCF_SEH_ONCE_PTR_DISPLACEMENT   -16
-".thumb_func                                                       \n\t"
-"  push.w {r0, r1, r11, lr}                                        \n\t"
-".seh_save_regs_w {r0, r1, r11, lr}                                \n\t"
-"  add.w r11, sp, #8                                               \n\t"
-".seh_nop_w                                                        \n\t"
-".seh_endprologue                                                  \n\t"
-/* Make the call `(*init_proc) (arg)`.  */
-"  mov.w r0, r2                                                    \n\t"
-"  blx r1                                                          \n\t"
-/* Disarm the once flag with a tail call.  */
-".seh_startepilogue                                                \n\t"
-"  pop.w {r0, r1, r11, lr}                                         \n\t"
-".seh_save_regs_w {r0, r1, r11, lr}                                \n\t"
-".seh_endepilogue                                                  \n\t"
-"  b.w _MCF_once_release                                           \n\t"
 #  elif defined __aarch64__
 /* The stack is used as follows:
  *

--- a/mcfgthread/thread.h
+++ b/mcfgthread/thread.h
@@ -368,30 +368,6 @@ _MCF_thread_self_tid(void) __MCF_NOEXCEPT
   }
 #endif
 
-#if defined __arm__ && (defined __GNUC__ || defined __clang__)
-/* ARM32, GCC or Clang  */
-__MCF_THREAD_INLINE
-uint32_t
-_MCF_thread_self_tid(void) __MCF_NOEXCEPT
-  {
-    char* __teb;
-    __asm__ ("mrc p15, #0, %0, c13, c0, #2" : "=r"(__teb));
-    return *(uint32_t*) (__teb + 0x24);
-  }
-#elif defined _M_ARM && defined _MSC_VER
-/* ARM32, MSVC  */
-__declspec(nothrow) unsigned _MoveFromCoprocessor(unsigned, unsigned, unsigned, unsigned, unsigned);
-#pragma intrinsic(_MoveFromCoprocessor)
-__MCF_THREAD_INLINE
-uint32_t
-_MCF_thread_self_tid(void) __MCF_NOEXCEPT
-  {
-    char* __teb;
-    __teb = (char*) _MoveFromCoprocessor(15, 0, 13, 0, 2);
-    return *(uint32_t*) (__teb + 0x24);
-  }
-#endif
-
 __MCF_THREAD_INLINE
 void*
 _MCF_tls_get(const _MCF_tls_key* __key) __MCF_NOEXCEPT

--- a/mcfgthread/xglobals.h
+++ b/mcfgthread/xglobals.h
@@ -42,6 +42,10 @@ __MCF_C_DECLARATIONS_BEGIN
 #  error Windows platforms are assumed to be little-endian.
 #endif
 
+#ifdef __arm__
+#  error 32-bit ARM target is not supported.
+#endif
+
 /* Undefine macros that redirect to standard functions.
  * This ensures we call the ones from KERNEL32.  */
 #undef RtlCopyMemory
@@ -161,13 +165,8 @@ __MCF_invoke_cxa_dtor(__MCF_cxa_dtor_union __dtor, void* __arg)
 #else
 /* Otherwise, SEH is table-based. `@unwind` without `@except` works only on
  * x86-64 and not on ARM, so let's keep both for simplicity.  */
-#  ifdef __arm__
-#    define __MCF_SEH_FLAG_EXCEPT   "%except"
-#    define __MCF_SEH_FLAG_UNWIND   "%except, %unwind"
-#  else
-#    define __MCF_SEH_FLAG_EXCEPT   "@except"
-#    define __MCF_SEH_FLAG_UNWIND   "@except, @unwind"
-#  endif
+#  define __MCF_SEH_FLAG_EXCEPT   "@except"
+#  define __MCF_SEH_FLAG_UNWIND   "@except, @unwind"
 
 #  define __MCF_SEH_DEFINE_TERMINATE_FILTER  \
     __asm__ (".seh_handler __MCF_seh_top, " __MCF_SEH_FLAG_EXCEPT)  /* no semicolon  */


### PR DESCRIPTION
Today I tried running tests on Windows 11 on ARM and linked failed due to lack of conversion routines between `long long` and `double`. ARM32 code has not been tested at all, and isn't likely working, so don't pretend it is actively maintained.