### PR TITLE
improves for meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,11 @@
 ## NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 ## CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-project('mcfgthread', [ 'c', 'cpp' ], version: '1.9.alpha')
+project(
+    'mcfgthread',
+    [ 'c', 'cpp' ],
+    version: '1.9.alpha',
+    default_options: ['c_std=c99', 'cpp_std=c++11', 'warning_level=2'])
 
 #===========================================================
 # List of files
@@ -216,10 +220,10 @@ ver.set('abi_minor', meson.project_version().split('.')[1])
 ver.set_quoted('abi_string', meson.project_version())
 
 cc = meson.get_compiler('c')
+cxx = meson.get_compiler('cpp')
 cc_is_i386 = cc.compiles('int foo = __i386__;')
 cc_is_amd64 = cc.compiles('int foo = __amd64__;')
-cc_asm_intel = cc.compiles('int foo(int a) { return a + 1; }',
-                           args: [ '-masm=intel' ])
+cc_asm_intel = cc.has_argument('-masm=intel')
 
 if cc_asm_intel
   add_project_arguments('-masm=intel', language: [ 'c', 'cpp' ])
@@ -234,24 +238,27 @@ if get_option('enable-debug-checks')
 endif
 
 add_project_arguments(
-    '-Wall', '-Wextra', '-Winvalid-pch', '-D_WIN32_WINNT=0x0601',
-    '-U_FORTIFY_SOURCE', '-fno-stack-protector', '-fstrict-aliasing',
-    '-ffast-math', '-fno-ident', '-Werror=conversion', '-Werror=sign-compare',
-    '-Werror=sign-conversion', '-Werror=write-strings', '-Werror=return-type',
-    '-Werror=double-promotion', '-Wmissing-declarations', '-Wswitch-enum',
-    '-Wmissing-field-initializers', '-Wsuggest-attribute=noreturn', '-Wshadow',
-    '-Wunused-function', '-Wunused-label', '-Wunused-local-typedefs',
-    '-Wunused-but-set-variable', '-Wunused-but-set-parameter',
+    cc.get_supported_arguments(
+        '-Winvalid-pch', '-D_WIN32_WINNT=0x0601', '-U_FORTIFY_SOURCE',
+        '-fno-stack-protector', '-fstrict-aliasing', '-ffast-math', '-fno-ident',
+        '-Werror=conversion', '-Werror=sign-compare', '-Werror=sign-conversion',
+        '-Werror=write-strings', '-Werror=return-type', '-Werror=double-promotion',
+        '-Wmissing-declarations', '-Wswitch-enum', '-Wmissing-field-initializers',
+        '-Wsuggest-attribute=noreturn', '-Wshadow', '-Wunused-function',
+        '-Wunused-label', '-Wunused-local-typedefs', '-Wunused-but-set-variable',
+        '-Wunused-but-set-parameter'),
     language: [ 'c', 'cpp' ])
 
 add_project_arguments(
-   '-std=c99', '-Werror=discarded-qualifiers', '-Werror=strict-prototypes',
-   '-Werror=incompatible-pointer-types', '-Werror=implicit-function-declaration',
-   '-Werror=int-conversion', '-Werror=implicit-int',
+   cc.get_supported_arguments(
+      '-Werror=discarded-qualifiers', '-Werror=strict-prototypes',
+      '-Werror=incompatible-pointer-types', '-Werror=implicit-function-declaration',
+      '-Werror=int-conversion', '-Werror=implicit-int'),
    language: 'c')
 
 add_project_arguments(
-   '-std=c++11', '-Wno-redundant-move', '-Wzero-as-null-pointer-constant',
+   cxx.get_supported_arguments(
+      '-Wno-redundant-move', '-Wzero-as-null-pointer-constant'),
    language: 'cpp')
 
 #===========================================================


### PR DESCRIPTION
- use `default_options` field for setting C and C++ standards and -Wall and -Wextra (warning_level=2 option)
- use `cc.has_argument` to check if `-masm=intel` works
- use `cc.get_supported_arguments` to add only supported warning options (fixes -Wunknown-warning-option for clang)