### PR TITLE
xglobals,thread: Replace some syscalls with public APIs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -66,7 +66,7 @@ jobs:
            export PATH=$(pwd)/llvm-mingw-20240308-ucrt-ubuntu-20.04-x86_64/bin:$PATH;
            meson setup --cross-file meson.cross.aarch64-w64-mingw32
            -Denable-debug-checks=true build_ci
-           && meson test -j2 -t12 -Cbuild_ci
+           && meson test -j3 -t12 -Cbuild_ci
 
   msys2-ucrt64:
     name: MSYS2 native build (x86-64 GCC)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ and unlocks the primitive mutex, releasing all threads that are waiting on it.
 |`ExitThread`                   |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitthread) |
 |`GetCurrentProcessId`          |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocessid) |
 |`GetLastError`                 |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror) |
-|`GetModuleHandleW`             |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandlew) |
+|`GetModuleHandleExW`           |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandleexw) |
 |`GetProcAddress`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress) |
 |`GetProcessHeap`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-getprocessheap) |
 |`GetSystemInfo`                |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo) |
@@ -190,18 +190,15 @@ and unlocks the primitive mutex, releasing all threads that are waiting on it.
 |`HeapFree`                     |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapfree) |
 |`HeapReAlloc`                  |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heaprealloc) |
 |`HeapSize`                     |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-heapsize) |
-|`LdrAddRefDll`                 |KERNEL32, NTDLL |Undocumented |
 |`NtClose`                      |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwclose) |
 |`NtCreateSection`              |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwcreatesection) |
 |`NtDelayExecution`             |NTDLL           |Undocumented |
 |`NtDuplicateObject`            |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwduplicateobject) |
 |`NtMapViewOfSection`           |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwmapviewofsection) |
-|`NtProtectVirtualMemory`       |NTDLL           |Undocumented |
 |`NtReleaseKeyedEvent`          |NTDLL           |Undocumented |
 |`NtUnmapViewOfSection`         |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwunmapviewofsection) |
 |`NtWaitForKeyedEvent`          |NTDLL           |Undocumented |
 |`NtWaitForSingleObject`        |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwwaitforsingleobject) |
-|`NtYieldExecution`             |NTDLL           |Undocumented |
 |`QueryPerformanceCounter`      |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter) |
 |`QueryPerformanceFrequency`    |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency) |
 |`QueryUnbiasedInterruptTime`   |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttime) |
@@ -213,7 +210,9 @@ and unlocks the primitive mutex, releasing all threads that are waiting on it.
 |`SetConsoleCtrlHandler`        |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/console/setconsolectrlhandler) |
 |`SetLastError`                 |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror) |
 |`SetThreadPriority`            |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadpriority) |
+|`SwitchToThread`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-switchtothread) |
 |`TerminateProcess`             |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminateprocess) |
 |`TlsAlloc`                     |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsalloc) |
 |`TlsGetValue`                  |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsgetvalue) |
 |`TlsSetValue`                  |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlssetvalue) |
+|`VirtualProtect`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualprotect) |

--- a/mcfgthread/thread.c
+++ b/mcfgthread/thread.c
@@ -198,8 +198,7 @@ __MCF_DLLEXPORT
 void
 _MCF_yield(void)
   {
-    NTSTATUS status = NtYieldExecution();
-    __MCF_ASSERT_NT(status);
+    SwitchToThread();
   }
 
 static

--- a/mcfgthread/xglobals.h
+++ b/mcfgthread/xglobals.h
@@ -71,15 +71,12 @@ __MCF_C_DECLARATIONS_BEGIN
 #define __MCF_CHECK_NT(...)   __MCF_CHECK((__VA_ARGS__) >= 0)
 #define __MCF_WINAPI(...)    __attribute__((__dllimport__, __nothrow__)) __VA_ARGS__ __stdcall
 
-/* Declare KERNEL32 APIs here.  */
 __MCF_WINAPI(DWORD) GetLastError(void) __attribute__((__pure__));
 __MCF_WINAPI(void) SetLastError(DWORD);
 __MCF_WINAPI(PVOID) EncodePointer(PVOID) __attribute__((__const__));
 __MCF_WINAPI(PVOID) DecodePointer(PVOID) __attribute__((__const__));
-__MCF_WINAPI(NTSTATUS) BaseGetNamedObjectDirectory(HANDLE*);
 
-/* Declare NTDLL (driver) APIs here.  */
-__MCF_WINAPI(NTSTATUS) LdrAddRefDll(ULONG, PVOID);
+__MCF_WINAPI(NTSTATUS) BaseGetNamedObjectDirectory(HANDLE*);
 __MCF_WINAPI(BOOLEAN) RtlDllShutdownInProgress(void) __attribute__((__const__));
 
 __MCF_WINAPI(void) RtlMoveMemory(void*, const void*, SIZE_T);
@@ -90,13 +87,11 @@ __MCF_WINAPI(SIZE_T) RtlCompareMemory(const void*, const void*, SIZE_T) __attrib
 __MCF_WINAPI(NTSTATUS) NtCreateSection(HANDLE*, ACCESS_MASK, OBJECT_ATTRIBUTES*, LARGE_INTEGER*, ULONG, ULONG, HANDLE);
 __MCF_WINAPI(NTSTATUS) NtMapViewOfSection(HANDLE, HANDLE, PVOID*, ULONG_PTR, SIZE_T, LARGE_INTEGER*, SIZE_T*, ULONG, ULONG, ULONG);
 __MCF_WINAPI(NTSTATUS) NtUnmapViewOfSection(HANDLE, PVOID);
-__MCF_WINAPI(NTSTATUS) NtProtectVirtualMemory(HANDLE, PVOID*, SIZE_T*, ULONG, ULONG*);
 
 __MCF_WINAPI(NTSTATUS) NtDuplicateObject(HANDLE, HANDLE, HANDLE, HANDLE*, ACCESS_MASK, ULONG, ULONG);
 __MCF_WINAPI(NTSTATUS) NtClose(HANDLE);
 __MCF_WINAPI(NTSTATUS) NtWaitForSingleObject(HANDLE, BOOLEAN, LARGE_INTEGER*);
 __MCF_WINAPI(NTSTATUS) NtDelayExecution(BOOLEAN, LARGE_INTEGER*);
-__MCF_WINAPI(NTSTATUS) NtYieldExecution(void);
 
 __MCF_WINAPI(NTSTATUS) NtWaitForKeyedEvent(HANDLE, PVOID, BOOLEAN, LARGE_INTEGER*);
 __MCF_WINAPI(NTSTATUS) NtReleaseKeyedEvent(HANDLE, PVOID, BOOLEAN, LARGE_INTEGER*);


### PR DESCRIPTION
* `LdrAddRefDll` -> `GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN, ...)`
* `NtProtectVirtualMemory` -> `VirtualProtect`
* `NtYieldExecution` -> `SwitchToThread`