### PR TITLE
fwd: Modernize `__MCF_runtime_failure()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ and unlocks the primitive mutex, releasing all threads that are waiting on it.
 |`DecodePointer`                |KERNEL32, NTDLL |[Windows API](https://learn.microsoft.com/en-us/previous-versions/bb432242(v=vs.85)) |
 |`EncodePointer`                |KERNEL32, NTDLL |[Windows API](https://learn.microsoft.com/en-us/previous-versions/bb432254(v=vs.85)) |
 |`ExitThread`                   |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-exitthread) |
+|`FormatMessageW`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagew) |
 |`GetCurrentProcessId`          |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocessid) |
 |`GetLastError`                 |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror) |
+|`GetModuleFileNameW`           |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew) |
 |`GetModuleHandleExW`           |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandleexw) |
 |`GetProcAddress`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress) |
 |`GetProcessHeap`               |KERNEL32        |[Windows API](https://learn.microsoft.com/en-us/windows/win32/api/heapapi/nf-heapapi-getprocessheap) |
@@ -195,6 +197,7 @@ and unlocks the primitive mutex, releasing all threads that are waiting on it.
 |`NtDelayExecution`             |NTDLL           |Undocumented |
 |`NtDuplicateObject`            |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-zwduplicateobject) |
 |`NtMapViewOfSection`           |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwmapviewofsection) |
+|`NtRaiseHardError`             |NTDLL           |Undocumented |
 |`NtReleaseKeyedEvent`          |NTDLL           |Undocumented |
 |`NtUnmapViewOfSection`         |NTDLL           |[Windows Driver API](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-zwunmapviewofsection) |
 |`NtWaitForKeyedEvent`          |NTDLL           |Undocumented |

--- a/mcfgthread/fwd.c
+++ b/mcfgthread/fwd.c
@@ -11,12 +11,104 @@
 #include "fwd.h"
 #include "xglobals.h"
 
+static inline
+void
+do_append_string(WCHAR** sp, PCWSTR end_of_buffer, WCHAR c)
+  {
+    if(*sp != end_of_buffer)
+      *((*sp) ++) = c;
+  }
+
+static
+DWORD
+do_format_message(DWORD code, WCHAR* outptr, PCWSTR end_of_buffer)
+  {
+    return FormatMessageW(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | 0xFF,
+        __MCF_nullptr, code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        outptr, (DWORD) (end_of_buffer - outptr), __MCF_nullptr);
+  }
+
 __MCF_DLLEXPORT
 void
 __MCF_runtime_failure(const char* where)
   {
-    /* `where` can be examined with a debugger.  */
-    __asm__ volatile ("" : : "m"(where) : "memory");
+    DWORD last_error = GetLastError();
+    WCHAR buffer[1536];
+    WCHAR* sptr = buffer;
+    WCHAR* end_of_buffer = buffer + RTL_NUMBER_OF(buffer);
+
+    /* Get a piece of localized text for the caption of the message box.  */
+    UNICODE_STRING caption;
+    caption.Buffer = sptr;
+    caption.Length = 0;
+    caption.MaximumLength = (USHORT) ((UINT_PTR) end_of_buffer - (UINT_PTR) sptr);
+
+    /* #define ERROR_UNHANDLED_EXCEPTION   574L
+     * {Application Error}
+     * The exception %s (0x%08lx) occurred in the application at location 0x%08lx.  */
+    WCHAR* lptr = end_of_buffer - 127;
+    DWORD outlen = do_format_message(574, lptr, end_of_buffer);
+    if((outlen != 0) && (*lptr == L'{')) {
+      lptr ++;
+
+      while((*lptr != 0) && (*lptr != L'}'))
+        do_append_string(&sptr, end_of_buffer, *(lptr ++));
+
+      caption.Length = (USHORT) ((UINT_PTR) sptr - (UINT_PTR) caption.Buffer);
+    }
+
+    /* Get a piece of localized text for the text of the message box.  */
+    UNICODE_STRING text;
+    text.Buffer = sptr;
+    text.Length = 0;
+    text.MaximumLength = (USHORT) ((UINT_PTR) end_of_buffer - (UINT_PTR) sptr);
+
+    /* Get the file name of the executable.  */
+    outlen = GetModuleFileNameW(NULL, sptr, (DWORD) (end_of_buffer - sptr));
+    if(outlen != 0) {
+      sptr += outlen;
+
+      do_append_string(&sptr, end_of_buffer, L'\r');
+      do_append_string(&sptr, end_of_buffer, L'\n');
+
+      text.Length = (USHORT) ((UINT_PTR) sptr - (UINT_PTR) text.Buffer);
+    }
+
+    /* #define ERROR_DEBUG_ATTACH_FAILED   590L
+     * {Unexpected Failure in DebugActiveProcess}
+     * An unexpected failure occurred while processing a DebugActiveProcess API
+     * request. You may choose OK to terminate the process, or Cancel to ignore
+     * the error.  */
+    lptr = end_of_buffer - 127;
+    outlen = do_format_message(590, lptr, end_of_buffer);
+    if((outlen != 0) && (*lptr == L'{')) {
+      lptr ++;
+
+      while((*lptr != 0) && (*lptr != L'}'))
+        if((*lptr == L'D') && __MCF_mequal(lptr, L"DebugActiveProcess", 18 * sizeof(WCHAR))) {
+          lptr += 18;
+          do_append_string(&sptr, end_of_buffer, L'`');
+          const char* lw = where;
+          while(*lw != 0) do_append_string(&sptr, end_of_buffer, (unsigned char) *(lw ++));
+          do_append_string(&sptr, end_of_buffer, L'`');
+        }
+        else
+          do_append_string(&sptr, end_of_buffer, *(lptr ++));
+
+      do_append_string(&sptr, end_of_buffer, L':');
+      do_append_string(&sptr, end_of_buffer, L' ');
+
+      outlen = do_format_message(last_error, sptr, end_of_buffer);
+      sptr += outlen;
+
+      text.Length = (USHORT) ((UINT_PTR) sptr - (UINT_PTR) text.Buffer);
+    }
+
+    /* If we are in a DLL entry-point function or a TLS callback, it is not safe
+     * to call `MessageBoxW()` from USER32.DLL, so request CSRSS.EXE to display
+     * the message box for us.  */
+    __MCF_show_hard_error_message_box(&caption, &text);
     TerminateProcess(GetCurrentProcess(), STATUS_FATAL_APP_EXIT);
     __builtin_unreachable();
   }

--- a/mcfgthread/xglobals.h
+++ b/mcfgthread/xglobals.h
@@ -666,5 +666,20 @@ __MCF_keyed_event_signal(const void* Key, const __MCF_winnt_timeout* Timeout) __
     return (status != STATUS_WAIT_0) ? -1 : 0;
   }
 
+/* Sends a hard-error LPC message to CSRSS.EXE. This function is useful in a DLL
+ * entry-point function or a TLS callback, where it is not safe to make a call
+ * to `MessageBox()`.  */
+NTSYSAPI NTSTATUS NTAPI NtRaiseHardError(NTSTATUS Status, ULONG NumberOfParameters, ULONG UnicodeStringParameterMask, ULONG_PTR* Parameters, ULONG ResponseOption, ULONG* Response);
+
+__MCF_ALWAYS_INLINE
+int
+__MCF_show_hard_error_message_box(const UNICODE_STRING* caption, const UNICODE_STRING* text) __MCF_NOEXCEPT
+  {
+    ULONG_PTR params[4] = { (ULONG_PTR) text, (ULONG_PTR) caption, MB_OK | MB_ICONSTOP, 0 };
+    ULONG response = 0;
+    NTSTATUS status = NtRaiseHardError(0x50000018, 4, 0b0011, params, 1, &response);
+    return !NT_SUCCESS(status) ? -1 : (int) response;
+  }
+
 __MCF_C_DECLARATIONS_END
 #endif  /* __MCFGTHREAD_XGLOBALS_  */


### PR DESCRIPTION
Closes #263.