### PR TITLE
Add a shared mutex / readers-write lock

### DIFF
--- a/mcfgthread/fwd.h
+++ b/mcfgthread/fwd.h
@@ -166,6 +166,7 @@ typedef struct __MCF_tls_element __MCF_tls_element;
 
 typedef struct __MCF_cond _MCF_cond;
 typedef struct __MCF_mutex _MCF_mutex;
+typedef struct __MCF_shared_mutex _MCF_shared_mutex;
 typedef struct __MCF_once _MCF_once;
 typedef struct __MCF_sem _MCF_sem;
 typedef struct __MCF_event _MCF_event;

--- a/mcfgthread/shared_mutex.c
+++ b/mcfgthread/shared_mutex.c
@@ -1,0 +1,163 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "xprecompiled.h"
+#define __MCF_SHARED_MUTEX_IMPORT  __MCF_DLLEXPORT
+#define __MCF_SHARED_MUTEX_INLINE  __MCF_DLLEXPORT
+#include "shared_mutex.h"
+#include "xglobals.h"
+
+__MCF_DLLEXPORT
+int
+_MCF_shared_mutex_lock_shared_slow(_MCF_shared_mutex* mutex, const int64_t* timeout_opt)
+  {
+    __MCF_winnt_timeout nt_timeout;
+    __MCF_initialize_winnt_timeout_v3(&nt_timeout, timeout_opt);
+
+    /* Grant shared access if and only if this shared mutex is either unlocked
+     * (`__nshare` = 0), or in shared mode and the share counter won't overflow
+     * (`__nshare` < `__MCF_SHARED_MUTEX_MAX_SHARE`). A reader shall not preempt
+     * a lock. If shared access can't be granted, allocate a sleeping count.  */
+    _MCF_shared_mutex old, new;
+    uint32_t shareable;
+  try_lock_loop:
+    _MCF_atomic_load_pptr_rlx(&old, mutex);
+#pragma GCC diagnostic ignored "-Wconversion"
+    do {
+      shareable = (uint32_t) ((old.__nshare - __MCF_SHARED_MUTEX_MAX_SHARE) & (old.__nsleep - 1U)) >> 31;
+      new.__nshare = old.__nshare + shareable;
+      new.__nsleep = old.__nsleep + 1U - shareable;
+    }
+    while(!_MCF_atomic_cmpxchg_weak_pptr_arl(mutex, &old, &new));
+#pragma GCC diagnostic pop
+
+    /* If this mutex has been locked by the current thread, succeed.  */
+    if(old.__nshare != new.__nshare)
+      return 0;
+
+    /* Try waiting.  */
+    int err = __MCF_keyed_event_wait(mutex, &nt_timeout);
+    while(err != 0) {
+      /* Tell another thread which is going to signal this mutex that an old
+       * waiter has left by decrementing the number of sleeping threads. But
+       * see below...  */
+      _MCF_atomic_load_pptr_rlx(&old, mutex);
+#pragma GCC diagnostic ignored "-Wconversion"
+      do {
+        if(old.__nsleep == 0)
+          break;
+
+        new.__nshare = old.__nshare;
+        new.__nsleep = old.__nsleep - 1U;
+      }
+      while(!_MCF_atomic_cmpxchg_weak_pptr_rlx(mutex, &old, &new));
+#pragma GCC diagnostic pop
+
+      if(old.__nsleep != 0)
+        return -1;
+
+      /* ... It is possible that a second thread has already decremented the
+       * counter. If this does take place, it is going to release the keyed
+       * event soon. We must still wait, otherwise we get a deadlock in the
+       * second thread. However, a third thread could start waiting for this
+       * keyed event before us, so we set the timeout to zero. If we time out
+       * once more, the third thread will have incremented the number of
+       * sleeping threads and we can try decrementing it again.  */
+      err = __MCF_keyed_event_wait(mutex, &(__MCF_winnt_timeout) { 0 });
+    }
+
+    /* We have got notified.  */
+    __MCF_adjust_winnt_timeout_v3(&nt_timeout);
+    goto try_lock_loop;
+  }
+
+__MCF_DLLEXPORT
+int
+_MCF_shared_mutex_lock_exclusive_slow(_MCF_shared_mutex* mutex, const int64_t* timeout_opt)
+  {
+    __MCF_winnt_timeout nt_timeout;
+    __MCF_initialize_winnt_timeout_v3(&nt_timeout, timeout_opt);
+
+    /* Grant exclusive access if and only if this shared mutex is unlocked
+     * (`__nshare` = 0). A writer may preempt a lock, even when other threads
+     * are waiting. If exclusive access can't be granted, allocate a sleeping
+     * count.  */
+    _MCF_shared_mutex old, new;
+  try_lock_loop:
+    _MCF_atomic_load_pptr_rlx(&old, mutex);
+#pragma GCC diagnostic ignored "-Wconversion"
+    do {
+      new.__nshare = old.__nshare + ((old.__nshare - 1U) >> 14);
+      new.__nsleep = old.__nsleep + ((old.__nshare + 0x3FFFU) >> 14);
+    }
+    while(!_MCF_atomic_cmpxchg_weak_pptr_arl(mutex, &old, &new));
+#pragma GCC diagnostic pop
+
+    /* If this mutex has been locked by the current thread, succeed.  */
+    if(old.__nshare == 0)
+      return 0;
+
+    /* Try waiting.  */
+    int err = __MCF_keyed_event_wait(mutex, &nt_timeout);
+    while(err != 0) {
+      /* Tell another thread which is going to signal this mutex that an old
+       * waiter has left by decrementing the number of sleeping threads. But
+       * see below...  */
+      _MCF_atomic_load_pptr_rlx(&old, mutex);
+#pragma GCC diagnostic ignored "-Wconversion"
+      do {
+        if(old.__nsleep == 0)
+          break;
+
+        new.__nshare = old.__nshare;
+        new.__nsleep = old.__nsleep - 1U;
+      }
+      while(!_MCF_atomic_cmpxchg_weak_pptr_rlx(mutex, &old, &new));
+#pragma GCC diagnostic pop
+
+      if(old.__nsleep != 0)
+        return -1;
+
+      /* ... It is possible that a second thread has already decremented the
+       * counter. If this does take place, it is going to release the keyed
+       * event soon. We must still wait, otherwise we get a deadlock in the
+       * second thread. However, a third thread could start waiting for this
+       * keyed event before us, so we set the timeout to zero. If we time out
+       * once more, the third thread will have incremented the number of
+       * sleeping threads and we can try decrementing it again.  */
+      err = __MCF_keyed_event_wait(mutex, &(__MCF_winnt_timeout) { 0 });
+    }
+
+    /* We have got notified.  */
+    __MCF_adjust_winnt_timeout_v3(&nt_timeout);
+    goto try_lock_loop;
+  }
+
+__MCF_DLLEXPORT __MCF_NEVER_INLINE
+void
+_MCF_shared_mutex_unlock_slow(_MCF_shared_mutex* mutex)
+  {
+    /* Determine whether the shared mutex has been locked in shared mode
+     * (`__nshare` <= `__MCF_SHARED_MUTEX_MAX_SHARE`) or exclusive mode. The
+     * last reader (`__nshare` = 1 before the call) or writer (`__nshare` =
+     * `__MCF_SHARED_MUTEX_NSHARE_M` before the call) that unlocks a shared
+     * mutex shall perform a wakeup operation.  */
+    size_t wake_one;
+    _MCF_shared_mutex old, new;
+    _MCF_atomic_load_pptr_rlx(&old, mutex);
+#pragma GCC diagnostic ignored "-Wconversion"
+    do {
+      __MCF_ASSERT(old.__nshare != 0);
+      wake_one = _MCF_minz(old.__nsleep, (((old.__nshare - 2U) ^ (old.__nshare + 1U)) >> 14) & 1U);
+      new.__nshare = old.__nshare - 1U + (((old.__nshare + 1U) >> 13) & 2U);
+      new.__nsleep = old.__nsleep - wake_one;
+    }
+    while(!_MCF_atomic_cmpxchg_weak_pptr_arl(mutex, &old, &new));
+#pragma GCC diagnostic pop
+
+    __MCF_batch_release_common(mutex, wake_one);
+  }

--- a/mcfgthread/shared_mutex.h
+++ b/mcfgthread/shared_mutex.h
@@ -1,0 +1,163 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#ifndef __MCFGTHREAD_SHARED_MUTEX_
+#define __MCFGTHREAD_SHARED_MUTEX_
+
+#include "fwd.h"
+#include "atomic.h"
+
+__MCF_C_DECLARATIONS_BEGIN
+#ifndef __MCF_SHARED_MUTEX_IMPORT
+#  define __MCF_SHARED_MUTEX_IMPORT
+#  define __MCF_SHARED_MUTEX_INLINE  __MCF_GNU_INLINE
+#endif
+
+/* Define the shared mutex struct.
+ * This takes up the same storage as a pointer.  */
+struct __MCF_shared_mutex
+  {
+    __MCF_EX uintptr_t __nshare : 14;  /* number of sharing threads  */
+    __MCF_EX uintptr_t __nsleep : __MCF_PTR_BITS - 14;  /* number of sleeping threads  */
+  };
+
+/* This is the maximum number of concurrent threads with shared access. If
+ * `__nshare` exceeds this value, further threads will block. This value meets
+ * the requirement of the C++ standard, which is 10000.  */
+#define __MCF_SHARED_MUTEX_MAX_SHARE   16382U
+
+/* Initializes a shared mutex dynamically. Static ones should be initialized with
+ * `{0}`, like other structs.  */
+__MCF_SHARED_MUTEX_INLINE
+void
+_MCF_shared_mutex_init(_MCF_shared_mutex* __mutex) __MCF_NOEXCEPT;
+
+/* Attempts to lock a shared mutex in shared mode.
+ *
+ * A shared mutex is not recursive and performs no error checking. If the caller
+ * attempts to lock a mutex which it has already held and there is another thread
+ * waiting for exclusive access, deadlocks may occur.
+ *
+ * If the `__timeout_opt` argument points to a positive integer, it denotes the
+ * expiration time in number of milliseconds since 1970-01-01T00:00:00Z. If it
+ * points to a negative integer, the absolute value of it denotes the number of
+ * milliseconds to wait. If it points to zero, the function returns immediately
+ * without waiting. If it is null, the function waits indefinitely.
+ *
+ * Returns 0 if the shared mutex has been locked in shared mode by the caller, or
+ * -1 if the operation has timed out.  */
+__MCF_SHARED_MUTEX_IMPORT
+int
+_MCF_shared_mutex_lock_shared_slow(_MCF_shared_mutex* __mutex, const int64_t* __timeout_opt) __MCF_NOEXCEPT;
+
+__MCF_SHARED_MUTEX_INLINE
+int
+_MCF_shared_mutex_lock_shared(_MCF_shared_mutex* __mutex, const int64_t* __timeout_opt) __MCF_NOEXCEPT;
+
+/* Attempts to lock a shared mutex in exclusive mode.
+ *
+ * A shared mutex is not recursive and performs no error checking. If the caller
+ * attempts to lock a mutex which it has already held, deadlocks may occur.
+ *
+ * If the `__timeout_opt` argument points to a positive integer, it denotes the
+ * expiration time in number of milliseconds since 1970-01-01T00:00:00Z. If it
+ * points to a negative integer, the absolute value of it denotes the number of
+ * milliseconds to wait. If it points to zero, the function returns immediately
+ * without waiting. If it is null, the function waits indefinitely.
+ *
+ * Returns 0 if the shared mutex has been locked in exclusive mode by the caller,
+ * or -1 if the operation has timed out.  */
+__MCF_SHARED_MUTEX_IMPORT
+int
+_MCF_shared_mutex_lock_exclusive_slow(_MCF_shared_mutex* __mutex, const int64_t* __timeout_opt) __MCF_NOEXCEPT;
+
+__MCF_SHARED_MUTEX_INLINE
+int
+_MCF_shared_mutex_lock_exclusive(_MCF_shared_mutex* __mutex, const int64_t* __timeout_opt) __MCF_NOEXCEPT;
+
+/* Releases a shared mutex, in either shared or exclusive mode. This function may
+ * be called by a different thread from which locked the same mutex. If the mutex
+ * has not been locked, the behavior is undefined.  */
+__MCF_SHARED_MUTEX_IMPORT
+void
+_MCF_shared_mutex_unlock_slow(_MCF_shared_mutex* __mutex) __MCF_NOEXCEPT;
+
+__MCF_SHARED_MUTEX_INLINE
+void
+_MCF_shared_mutex_unlock(_MCF_shared_mutex* __mutex) __MCF_NOEXCEPT;
+
+/* Define inline functions after all declarations.
+ * We would like to keep them away from declarations for conciseness, which also
+ * matches the disposition of non-inline functions. Note that however, unlike C++
+ * inline functions, they have to have consistent inline specifiers throughout
+ * this file.  */
+__MCF_SHARED_MUTEX_INLINE
+void
+_MCF_shared_mutex_init(_MCF_shared_mutex* __mutex) __MCF_NOEXCEPT
+  {
+    _MCF_shared_mutex __temp = __MCF_0_INIT;
+    _MCF_atomic_store_pptr_rel(__mutex, &__temp);
+  }
+
+__MCF_SHARED_MUTEX_INLINE
+int
+_MCF_shared_mutex_lock_shared(_MCF_shared_mutex* __mutex, const int64_t* __timeout_opt) __MCF_NOEXCEPT
+  {
+#if defined __OPTIMIZE__ && !defined __OPTIMIZE_SIZE__
+    _MCF_shared_mutex __old = { 0, 0 };
+    _MCF_shared_mutex __new = { 1, 0 };
+
+    /* This is optimized solely for single-thread code.  */
+    if(_MCF_atomic_cmpxchg_weak_pptr_acq(__mutex, &__old, &__new))
+      return 0;
+
+    /* If a timeout of zero is specified, don't block at all.  */
+    if(__timeout_opt && (*__timeout_opt == 0) && __old.__locked)
+      return -1;
+#endif  /* speed */
+
+    return _MCF_shared_mutex_lock_shared_slow(__mutex, __timeout_opt);
+  }
+
+__MCF_SHARED_MUTEX_INLINE
+int
+_MCF_shared_mutex_lock_exclusive(_MCF_shared_mutex* __mutex, const int64_t* __timeout_opt) __MCF_NOEXCEPT
+  {
+#if defined __OPTIMIZE__ && !defined __OPTIMIZE_SIZE__
+    _MCF_shared_mutex __old = { 0, 0 };
+    _MCF_shared_mutex __new = { 0x3FFF, 0 };
+
+    /* This is optimized solely for single-thread code.  */
+    if(_MCF_atomic_cmpxchg_weak_pptr_acq(__mutex, &__old, &__new))
+      return 0;
+
+    /* If a timeout of zero is specified, don't block at all.  */
+    if(__timeout_opt && (*__timeout_opt == 0) && __old.__locked)
+      return -1;
+#endif  /* speed */
+
+    return _MCF_shared_mutex_lock_exclusive_slow(__mutex, __timeout_opt);
+  }
+
+__MCF_SHARED_MUTEX_INLINE
+void
+_MCF_shared_mutex_unlock(_MCF_shared_mutex* __mutex) __MCF_NOEXCEPT
+  {
+#if defined __OPTIMIZE__ && !defined __OPTIMIZE_SIZE__
+    _MCF_shared_mutex __old = { 1, 0 };
+    _MCF_shared_mutex __new = { 0, 0 };
+
+    /* This is optimized solely for single-thread code.  */
+    if(_MCF_atomic_cmpxchg_weak_pptr_rel(__mutex, &__old, &__new))
+      return;
+#endif  /* speed */
+
+    _MCF_shared_mutex_unlock_slow(__mutex);
+  }
+
+__MCF_C_DECLARATIONS_END
+#endif  /* __MCFGTHREAD_SHARED_MUTEX_  */

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ mcfgthread_include = [
   'mcfgthread/fwd.h',
   'mcfgthread/clock.h',
   'mcfgthread/mutex.h',
+  'mcfgthread/shared_mutex.h',
   'mcfgthread/cond.h',
   'mcfgthread/once.h',
   'mcfgthread/sem.h',
@@ -51,6 +52,7 @@ mcfgthread_src_min = [
   'mcfgthread/fwd.c',
   'mcfgthread/clock.c',
   'mcfgthread/mutex.c',
+  'mcfgthread/shared_mutex.c',
   'mcfgthread/cond.c',
   'mcfgthread/once.c',
   'mcfgthread/sem.c',
@@ -88,6 +90,11 @@ test_src = [
   'test/mutex_zero_timeout.c',
   'test/mutex_timeout.c',
   'test/mutex.c',
+  'test/shared_mutex_zero_timeout.c',
+  'test/shared_mutex_timeout.c',
+  'test/shared_mutex_shared.c',
+  'test/shared_mutex_shared_too_many.c',
+  'test/shared_mutex_exclusive.c',
   'test/cond_timeout.c',
   'test/cond_multi_wait.c',
   'test/sem_init.c',
@@ -192,12 +199,22 @@ test_src = [
   'test/at_quick_exit_ignored_on__Exit.c',
   'test/cxx11_no_exceptions.cpp',
   'test/cxx11_pedantic.cpp',
+  'test/cxx14_pedantic.cpp',
   'test/mutex_ctor_constexpr.cpp',
   'test/mutex.cpp',
   'test/mutex_nonrecursive.cpp',
   'test/mutex_try_lock.cpp',
   'test/timed_mutex_try_lock_until.cpp',
   'test/timed_mutex_try_lock_for.cpp',
+  'test/shared_mutex_ctor_constexpr.cpp',
+  'test/shared_mutex_shared.cpp',
+  'test/shared_mutex_exclusive.cpp',
+  'test/shared_mutex_try_lock_shared.cpp',
+  'test/shared_mutex_try_lock_exclusive.cpp',
+  'test/shared_timed_mutex_try_lock_shared_until.cpp',
+  'test/shared_timed_mutex_try_lock_exclusive_until.cpp',
+  'test/shared_timed_mutex_try_lock_shared_for.cpp',
+  'test/shared_timed_mutex_try_lock_exclusive_for.cpp',
   'test/condition_variable_consumers.cpp',
   'test/condition_variable_wait_until.cpp',
   'test/condition_variable_wait_for.cpp',
@@ -381,6 +398,18 @@ foreach src: test_src
 
   if src in [ 'test/cxx11_pedantic.cpp' ]
     test_cpp_args = [ '-std=c++11', '-Wpedantic' ]
+  endif
+
+  if src in [ 'test/cxx14_pedantic.cpp' ]
+    test_cpp_args = [ '-std=c++14', '-Wpedantic' ]
+  endif
+
+  if src.startswith('test/shared_mutex_')
+    test_cpp_args = [ '-std=c++17' ]
+  endif
+
+  if src.startswith('test/shared_timed_mutex_')
+    test_cpp_args = [ '-std=c++14' ]
   endif
 
   test_exe = executable(src.underscorify(), src,

--- a/test/cxx14_pedantic.cpp
+++ b/test/cxx14_pedantic.cpp
@@ -1,0 +1,18 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+
+#if __cplusplus < 201402L
+#  error Please compile this file as C++14.
+#endif
+
+int
+main(void)
+  {
+    return 0;
+  }

--- a/test/shared_mutex_ctor_constexpr.cpp
+++ b/test/shared_mutex_ctor_constexpr.cpp
@@ -1,0 +1,21 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+
+int
+main(void)
+  {
+#ifdef TEST_STD
+    return 77;  // skip
+#else
+    constexpr _MCF::shared_mutex m1;
+    constexpr _MCF::shared_mutex m2{};
+    (void) m1;
+    (void) m2;
+#endif
+  }

--- a/test/shared_mutex_exclusive.c
+++ b/test/shared_mutex_exclusive.c
@@ -1,0 +1,54 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/shared_mutex.h"
+#include "../mcfgthread/thread.h"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+
+#define NTHREADS  64U
+static _MCF_thread* threads[NTHREADS];
+static _MCF_shared_mutex mutex;
+static _MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+thread_proc(_MCF_thread* self)
+  {
+    _MCF_sem_wait(&start, __MCF_nullptr);
+
+    int r = _MCF_shared_mutex_lock_exclusive(&mutex, __MCF_nullptr);
+    assert(r == 0);
+
+    /* Add a resource.  */
+    int old = resource;
+    _MCF_sleep((const int64_t[]) { -10 });
+    resource = old + 1;
+    _MCF_shared_mutex_unlock(&mutex);
+
+    printf("thread %d quitting\n", self->__tid);
+  }
+
+int
+main(void)
+  {
+    for(size_t k = 0;  k < NTHREADS;  ++k) {
+      threads[k] = _MCF_thread_new(thread_proc, __MCF_nullptr, 0);
+      assert(threads[k]);
+    }
+
+    printf("main waiting\n");
+    _MCF_sem_signal_some(&start, NTHREADS);
+    for(size_t k = 0;  k < NTHREADS;  ++k) {
+      _MCF_thread_wait(threads[k], __MCF_nullptr);
+      printf("main wait finished: %d\n", (int)k);
+    }
+
+    assert(resource == NTHREADS);
+  }

--- a/test/shared_mutex_exclusive.cpp
+++ b/test/shared_mutex_exclusive.cpp
@@ -1,0 +1,59 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+#include <vector>
+
+#ifdef TEST_STD
+#  include <mutex>
+#  include <shared_mutex>
+#  include <thread>
+#  include <chrono>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+constexpr std::size_t NTHREADS = 64U;
+static std::vector<NS::thread> threads(NTHREADS);
+static NS::shared_mutex mutex;
+static ::_MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+thread_proc()
+  {
+    ::_MCF_sem_wait(&start, nullptr);
+
+    NS::lock_guard<NS::shared_mutex> lock(mutex);
+
+    // Add a resource.
+    int old = resource;
+    NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+    resource = old + 1;
+
+    ::printf("thread %d quitting\n", (int) ::_MCF_thread_self_tid());
+  }
+
+int
+main(void)
+  {
+    for(auto& thr : threads)
+      thr = NS::thread(thread_proc);
+
+    ::printf("main waiting\n");
+    ::_MCF_sem_signal_some(&start, NTHREADS);
+
+    for(auto& thr : threads)
+      thr.join();
+
+    assert(resource == NTHREADS);
+  }

--- a/test/shared_mutex_shared.c
+++ b/test/shared_mutex_shared.c
@@ -1,0 +1,54 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/shared_mutex.h"
+#include "../mcfgthread/thread.h"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+
+#define NTHREADS  64U
+static _MCF_thread* threads[NTHREADS];
+static _MCF_shared_mutex mutex;
+static _MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+thread_proc(_MCF_thread* self)
+  {
+    _MCF_sem_wait(&start, __MCF_nullptr);
+
+    int r = _MCF_shared_mutex_lock_shared(&mutex, __MCF_nullptr);
+    assert(r == 0);
+
+    /* Add a resource.  */
+    int old = _MCF_atomic_load_32_rlx(&resource);
+    _MCF_sleep((const int64_t[]) { -10 });
+    _MCF_atomic_store_32_rlx(&resource, old + 1);
+    _MCF_shared_mutex_unlock(&mutex);
+
+    printf("thread %d quitting\n", self->__tid);
+  }
+
+int
+main(void)
+  {
+    for(size_t k = 0;  k < NTHREADS;  ++k) {
+      threads[k] = _MCF_thread_new(thread_proc, __MCF_nullptr, 0);
+      assert(threads[k]);
+    }
+
+    printf("main waiting\n");
+    _MCF_sem_signal_some(&start, NTHREADS);
+    for(size_t k = 0;  k < NTHREADS;  ++k) {
+      _MCF_thread_wait(threads[k], __MCF_nullptr);
+      printf("main wait finished: %d\n", (int)k);
+    }
+
+    assert(resource < (int) NTHREADS);
+  }

--- a/test/shared_mutex_shared.cpp
+++ b/test/shared_mutex_shared.cpp
@@ -1,0 +1,60 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+#include <vector>
+#include <atomic>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <thread>
+#  include <chrono>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+constexpr std::size_t NTHREADS = 64U;
+static std::vector<NS::thread> threads(NTHREADS);
+static NS::shared_mutex mutex;
+static ::_MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static std::atomic<int> resource(0);
+
+static
+void
+thread_proc()
+  {
+    ::_MCF_sem_wait(&start, nullptr);
+
+    NS::shared_lock<NS::shared_mutex> lock(mutex);
+
+    // Add a resource.
+    int old = resource.load();
+    NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+    resource.store(old + 1);
+
+    ::printf("thread %d quitting\n", (int) ::_MCF_thread_self_tid());
+  }
+
+int
+main(void)
+  {
+    for(auto& thr : threads)
+      thr = NS::thread(thread_proc);
+
+    ::printf("main waiting\n");
+    ::_MCF_sem_signal_some(&start, NTHREADS);
+
+    for(auto& thr : threads)
+      thr.join();
+
+    assert(resource.load() < (int) NTHREADS);
+  }

--- a/test/shared_mutex_shared_too_many.c
+++ b/test/shared_mutex_shared_too_many.c
@@ -1,0 +1,31 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/shared_mutex.h"
+#include <assert.h>
+#include <stdio.h>
+
+int
+main(void)
+  {
+    int r;
+    _MCF_shared_mutex mtx = __MCF_0_INIT;
+    assert(mtx.__nshare == 0);
+    assert(mtx.__nsleep == 0);
+
+    for(unsigned i = 1;  i <= __MCF_SHARED_MUTEX_MAX_SHARE;  ++i) {
+      r = _MCF_shared_mutex_lock_shared(&mtx, &(int64_t) { 0 });
+      assert(r == 0);
+      assert(mtx.__nshare == i);
+      assert(mtx.__nsleep == 0);
+    }
+
+    r = _MCF_shared_mutex_lock_shared(&mtx, &(int64_t) { 0 });
+    assert(r == -1);
+    assert(mtx.__nshare == __MCF_SHARED_MUTEX_MAX_SHARE);
+    assert(mtx.__nsleep == 0);
+  }

--- a/test/shared_mutex_timeout.c
+++ b/test/shared_mutex_timeout.c
@@ -1,0 +1,107 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/shared_mutex.h"
+#include "../mcfgthread/clock.h"
+#include "../mcfgthread/thread.h"
+#include <assert.h>
+#include <stdio.h>
+
+static _MCF_shared_mutex mutex;
+
+int
+main(void)
+  {
+    double now, delta;
+    int r;
+
+    _MCF_thread_set_priority(__MCF_nullptr, _MCF_thread_priority_above_normal);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_shared(&mutex, (const int64_t[]){ (int64_t) _MCF_hires_utc_now() + 1100 });  /* absolute  */
+    assert(r == 0);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_exclusive(&mutex, (const int64_t[]){ (int64_t) _MCF_hires_utc_now() + 1100 });  /* absolute  */
+    assert(r == -1);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 1100 - 40);
+    assert(delta <= 1200);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_exclusive(&mutex, (const int64_t[]){ -1100 });  /* relative  */
+    assert(r == -1);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 1100 - 40);
+    assert(delta <= 1200);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_shared(&mutex, (const int64_t[]){ (int64_t) _MCF_hires_utc_now() + 1100 });  /* absolute  */
+    assert(r == 0);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_shared(&mutex, (const int64_t[]){ -1100 });  /* relative  */
+    assert(r == 0);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    _MCF_shared_mutex_unlock(&mutex);
+    _MCF_shared_mutex_unlock(&mutex);
+    _MCF_shared_mutex_unlock(&mutex);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_exclusive(&mutex, (const int64_t[]){ (int64_t) _MCF_hires_utc_now() + 1100 });  /* absolute  */
+    assert(r == 0);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_exclusive(&mutex, (const int64_t[]){ (int64_t) _MCF_hires_utc_now() + 1100 });  /* absolute  */
+    assert(r == -1);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 1100 - 40);
+    assert(delta <= 1200);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_exclusive(&mutex, (const int64_t[]){ -1100 });  /* relative  */
+    assert(r == -1);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 1100 - 40);
+    assert(delta <= 1200);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_shared(&mutex, (const int64_t[]){ (int64_t) _MCF_hires_utc_now() + 1100 });  /* absolute  */
+    assert(r == -1);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 1100 - 40);
+    assert(delta <= 1200);
+
+    now = _MCF_perf_counter();
+    r = _MCF_shared_mutex_lock_shared(&mutex, (const int64_t[]){ -1100 });  /* relative  */
+    assert(r == -1);
+    delta = _MCF_perf_counter() - now;
+    printf("delta = %.6f\n", delta);
+    assert(delta >= 1100 - 40);
+    assert(delta <= 1200);
+  }

--- a/test/shared_mutex_try_lock_exclusive.cpp
+++ b/test/shared_mutex_try_lock_exclusive.cpp
@@ -1,0 +1,65 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+#include <vector>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <thread>
+#  include <chrono>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+constexpr std::size_t NTHREADS = 64U;
+static std::vector<NS::thread> threads(NTHREADS);
+static NS::shared_mutex mutex;
+static ::_MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+thread_proc()
+  {
+    ::_MCF_sem_wait(&start, nullptr);
+
+    for(;;) {
+      NS::unique_lock<NS::shared_mutex> lock(mutex, NS::try_to_lock);
+      if(lock) {
+        // Add a resource.
+        int old = resource;
+        NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+        resource = old + 1;
+        break;
+      }
+      else
+        NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+    }
+
+    ::printf("thread %d quitting\n", (int) ::_MCF_thread_self_tid());
+  }
+
+int
+main(void)
+  {
+    for(auto& thr : threads)
+      thr = NS::thread(thread_proc);
+
+    ::printf("main waiting\n");
+    ::_MCF_sem_signal_some(&start, NTHREADS);
+
+    for(auto& thr : threads)
+      thr.join();
+
+    assert(resource == NTHREADS);
+  }

--- a/test/shared_mutex_try_lock_shared.cpp
+++ b/test/shared_mutex_try_lock_shared.cpp
@@ -1,0 +1,66 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+#include <vector>
+#include <atomic>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <thread>
+#  include <chrono>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+constexpr std::size_t NTHREADS = 64U;
+static std::vector<NS::thread> threads(NTHREADS);
+static NS::shared_mutex mutex;
+static ::_MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static std::atomic<int> resource(0);
+
+static
+void
+thread_proc()
+  {
+    ::_MCF_sem_wait(&start, nullptr);
+
+    for(;;) {
+      NS::shared_lock<NS::shared_mutex> lock(mutex, NS::try_to_lock);
+      if(lock) {
+        // Add a resource.
+        int old = resource.load();
+        NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+        resource.store(old + 1);
+        break;
+      }
+      else
+        NS::this_thread::sleep_for(NS::chrono::milliseconds(10));
+    }
+
+    ::printf("thread %d quitting\n", (int) ::_MCF_thread_self_tid());
+  }
+
+int
+main(void)
+  {
+    for(auto& thr : threads)
+      thr = NS::thread(thread_proc);
+
+    ::printf("main waiting\n");
+    ::_MCF_sem_signal_some(&start, NTHREADS);
+
+    for(auto& thr : threads)
+      thr.join();
+
+    assert(resource.load() < (int) NTHREADS);
+  }

--- a/test/shared_mutex_zero_timeout.c
+++ b/test/shared_mutex_zero_timeout.c
@@ -1,0 +1,66 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/shared_mutex.h"
+#include "../mcfgthread/thread.h"
+#include "../mcfgthread/sem.h"
+#include <assert.h>
+#include <stdio.h>
+
+#define NTHREADS  64U
+static _MCF_thread* threads[NTHREADS];
+static _MCF_shared_mutex mutex;
+static _MCF_sem start = __MCF_SEM_INIT(NTHREADS);
+static int resource = 0;
+
+static
+void
+thread_proc(_MCF_thread* self)
+  {
+    _MCF_sem_wait(&start, __MCF_nullptr);
+
+    for(;;) {
+      int r = _MCF_shared_mutex_lock_exclusive(&mutex, (const int64_t[]){ 0 });
+      if(r == 0) {
+        printf("thread %d got %d\n", self->__tid, r);
+
+        /* Add a resource.  */
+        int old = resource;
+        _MCF_sleep((const int64_t[]) { -10 });
+        resource = old + 1;
+        _MCF_shared_mutex_unlock(&mutex);
+        break;
+      }
+      else if(r == -1) {
+        /* Wait.  */
+        _MCF_sleep((const int64_t[]) { -10 });
+        continue;
+      }
+      else
+        assert(0);
+    }
+
+    printf("thread %d quitting\n", self->__tid);
+  }
+
+int
+main(void)
+  {
+    for(size_t k = 0;  k < NTHREADS;  ++k) {
+      threads[k] = _MCF_thread_new(thread_proc, __MCF_nullptr, 0);
+      assert(threads[k]);
+    }
+
+    printf("main waiting\n");
+    _MCF_sem_signal_some(&start, NTHREADS);
+    for(size_t k = 0;  k < NTHREADS;  ++k) {
+      _MCF_thread_wait(threads[k], __MCF_nullptr);
+      printf("main wait finished: %d\n", (int)k);
+    }
+
+    assert(resource == NTHREADS);
+  }

--- a/test/shared_timed_mutex_try_lock_exclusive_for.cpp
+++ b/test/shared_timed_mutex_try_lock_exclusive_for.cpp
@@ -1,0 +1,65 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/clock.h"
+#include "../mcfgthread/thread.h"
+#include <assert.h>
+#include <stdio.h>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <chrono>
+#  include <thread>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+static NS::shared_timed_mutex mutex;
+
+int
+main(void)
+  {
+    double now, delta;
+    bool r;
+
+    ::_MCF_thread_set_priority(nullptr, ::_MCF_thread_priority_above_normal);
+
+    now = ::_MCF_perf_counter();
+    r = mutex.try_lock_for(NS::chrono::milliseconds(1100));
+    assert(r == true);
+    delta = ::_MCF_perf_counter() - now;
+    ::printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_shared_for(NS::chrono::milliseconds(1100));
+       assert(r == false);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 1100 - 20);
+       assert(delta <= 1200);
+     })
+     .join();
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_for(NS::chrono::milliseconds(1100));
+       assert(r == false);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 1100 - 20);
+       assert(delta <= 1200);
+     })
+     .join();
+  }

--- a/test/shared_timed_mutex_try_lock_exclusive_until.cpp
+++ b/test/shared_timed_mutex_try_lock_exclusive_until.cpp
@@ -1,0 +1,69 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/clock.h"
+#include "../mcfgthread/thread.h"
+#include <assert.h>
+#include <stdio.h>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <chrono>
+#  include <thread>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+static NS::shared_timed_mutex mutex;
+
+int
+main(void)
+  {
+    double now, delta;
+    bool r;
+
+    ::_MCF_thread_set_priority(nullptr, ::_MCF_thread_priority_above_normal);
+
+    // Round the time up.
+    int64_t sleep_until = (int64_t) ::time(nullptr) * 1000 + 2000;
+    ::_MCF_sleep(&sleep_until);
+
+    now = ::_MCF_perf_counter();
+    r = mutex.try_lock_until(NS::chrono::system_clock::now() + NS::chrono::milliseconds(1100));
+    assert(r == true);
+    delta = ::_MCF_perf_counter() - now;
+    ::printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_shared_until(NS::chrono::system_clock::now() + NS::chrono::milliseconds(1100));
+       assert(r == false);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 1100 - 20);
+       assert(delta <= 1200);
+     })
+     .join();
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_until(NS::chrono::system_clock::now() + NS::chrono::milliseconds(1100));
+       assert(r == false);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 1100 - 20);
+       assert(delta <= 1200);
+     })
+     .join();
+  }

--- a/test/shared_timed_mutex_try_lock_shared_for.cpp
+++ b/test/shared_timed_mutex_try_lock_shared_for.cpp
@@ -1,0 +1,65 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/clock.h"
+#include "../mcfgthread/thread.h"
+#include <assert.h>
+#include <stdio.h>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <chrono>
+#  include <thread>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+static NS::shared_timed_mutex mutex;
+
+int
+main(void)
+  {
+    double now, delta;
+    bool r;
+
+    ::_MCF_thread_set_priority(nullptr, ::_MCF_thread_priority_above_normal);
+
+    now = ::_MCF_perf_counter();
+    r = mutex.try_lock_shared_for(NS::chrono::milliseconds(1100));
+    assert(r == true);
+    delta = ::_MCF_perf_counter() - now;
+    ::printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_shared_for(NS::chrono::milliseconds(1100));
+       assert(r == true);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 0);
+       assert(delta <= 100);
+     })
+     .join();
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_for(NS::chrono::milliseconds(1100));
+       assert(r == false);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 1100 - 20);
+       assert(delta <= 1200);
+     })
+     .join();
+  }

--- a/test/shared_timed_mutex_try_lock_shared_until.cpp
+++ b/test/shared_timed_mutex_try_lock_shared_until.cpp
@@ -1,0 +1,69 @@
+/* This file is part of MCF Gthread.
+ * Copyright (C) 2022-2024 LH_Mouse. All wrongs reserved.
+ *
+ * MCF Gthread is free software. Licensing information is included in
+ * LICENSE.TXT as a whole. The GCC Runtime Library Exception applies
+ * to this file.  */
+
+#include "../mcfgthread/cxx11.hpp"
+#include "../mcfgthread/clock.h"
+#include "../mcfgthread/thread.h"
+#include <assert.h>
+#include <stdio.h>
+
+#ifdef TEST_STD
+#  include <shared_mutex>
+#  include <mutex>
+#  include <chrono>
+#  include <thread>
+namespace NS = std;
+#else
+namespace NS = ::_MCF;
+#endif
+
+static NS::shared_timed_mutex mutex;
+
+int
+main(void)
+  {
+    double now, delta;
+    bool r;
+
+    ::_MCF_thread_set_priority(nullptr, ::_MCF_thread_priority_above_normal);
+
+    // Round the time up.
+    int64_t sleep_until = (int64_t) ::time(nullptr) * 1000 + 2000;
+    ::_MCF_sleep(&sleep_until);
+
+    now = ::_MCF_perf_counter();
+    r = mutex.try_lock_shared_until(NS::chrono::system_clock::now() + NS::chrono::milliseconds(1100));
+    assert(r == true);
+    delta = ::_MCF_perf_counter() - now;
+    ::printf("delta = %.6f\n", delta);
+    assert(delta >= 0);
+    assert(delta <= 100);
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_shared_until(NS::chrono::system_clock::now() + NS::chrono::milliseconds(1100));
+       assert(r == true);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 0);
+       assert(delta <= 100);
+     })
+     .join();
+
+    NS::thread(
+     [&] {
+       now = ::_MCF_perf_counter();
+       r = mutex.try_lock_until(NS::chrono::system_clock::now() + NS::chrono::milliseconds(1100));
+       assert(r == false);
+       delta = ::_MCF_perf_counter() - now;
+       ::printf("delta = %.6f\n", delta);
+       assert(delta >= 1100 - 20);
+       assert(delta <= 1200);
+     })
+     .join();
+  }


### PR DESCRIPTION
### 'New Folder'

Add the new type `__MCF_shared_mutex`, like POSIX `pthread_rwlock_t`.

1. The mutex may be locked in either shared mode or exclusive mode.
2. There is only one unlocking function.
3. Writers are preferred and may preempt a mutex.
