### PR TITLE
ci: Use hosted ARM64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,34 +45,33 @@ jobs:
 
   linaro-ubuntu-arm64:
     name: Ubuntu cross build (ARM64 Clang)
-    runs-on: ubuntu-latest
-    container: linaro/wine-arm64
+    runs-on: ubuntu-22.04-arm
 
     steps:
     - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: >-
-           apt-get update &&
-           apt-get install -y --no-install-recommends
-           ninja-build python3-pip
+           sudo apt-get update &&
+           sudo apt-get install -y --no-install-recommends
+           ninja-build python3-pip wine wine-binfmt
 
     - name: Install newest meson
       run: >-
-           PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install meson
+           sudo PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install meson
 
     - name: Download llvm-mingw
       run: >-
-           wget 'https://github.com/mstorsjo/llvm-mingw/releases/download/20240917/llvm-mingw-20240917-ucrt-ubuntu-20.04-x86_64.tar.xz'
-           && tar -xaf llvm-mingw-20240917-ucrt-ubuntu-20.04-x86_64.tar.xz
+           wget 'https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-ubuntu-20.04-aarch64.tar.xz'
+           && tar -xaf llvm-mingw-20250114-ucrt-ubuntu-20.04-aarch64.tar.xz
 
     - name: Run tests
       run: >-
-           export PATH=$(pwd)/llvm-mingw-20240917-ucrt-ubuntu-20.04-x86_64/bin:$PATH;
+           export PATH=$(pwd)/llvm-mingw-20250114-ucrt-ubuntu-20.04-aarch64/bin:$PATH;
            meson setup --cross-file meson.cross.aarch64-w64-mingw32
            -Denable-debug-checks=true -Doptimization=1 build_ci
            && meson compile -Cbuild_ci
-           && meson test -t60 -Cbuild_ci
+           && meson test -t20 -Cbuild_ci
 
   msys2-ucrt64:
     name: MSYS2 native build (x86-64 GCC)

--- a/meson.cross.aarch64-w64-mingw32
+++ b/meson.cross.aarch64-w64-mingw32
@@ -8,7 +8,7 @@ ar = 'aarch64-w64-mingw32-ar'
 strip = 'aarch64-w64-mingw32-strip'
 windres = 'aarch64-w64-mingw32-windres'
 pkg-config = 'aarch64-w64-mingw32-pkg-config'
-exe_wrapper = 'wine-arm64'
+exe_wrapper = 'wine'
 
 [host_machine]
 system = 'windows'


### PR DESCRIPTION
Reference: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/