### PR TITLE
xglobals,gthr_aux: Register safe SE handlers for GNU binutils

### DIFF
--- a/mcfgthread/gthr_aux.c
+++ b/mcfgthread/gthr_aux.c
@@ -22,9 +22,6 @@ __asm__ (
 /* On x86, SEH is stack-based.  */
 ".def _do_call_once_seh_take_over; .scl 3; .type 32; .endef  \n"
 "_do_call_once_seh_take_over:  \n"
-#  ifdef _MSC_VER
-".safeseh _do_call_once_seh_uhandler  \n"
-#  endif
 /* The stack is used as follows:
  *
  *    -20: argument to subroutines
@@ -154,6 +151,17 @@ do_call_once_seh_uhandler(EXCEPTION_RECORD* rec, PVOID estab_frame, CONTEXT* ctx
     /* Continue unwinding.  */
     return ExceptionContinueSearch;
   }
+
+#ifdef __i386__
+__asm__ (
+#  if defined __MCF_IN_DLL
+".globl ___MCF_i386_se_handler_0001  \n"
+".equiv ___MCF_i386_se_handler_0001, _do_call_once_seh_uhandler  \n"
+#  elif defined _MSC_VER
+".safeseh _do_call_once_seh_uhandler  \n"
+#  endif
+"");
+#endif
 
 __MCF_DLLEXPORT
 void

--- a/mcfgthread/xglobals.h
+++ b/mcfgthread/xglobals.h
@@ -113,9 +113,6 @@ __MCF_ALWAYS_INLINE
 __MCF_i386_seh_node*
 __MCF_i386_seh_install(__MCF_i386_seh_node* node)
   {
-#  ifdef _MSC_VER
-    __asm__ (".safeseh ___MCF_seh_top");
-#  endif
     __MCF_TEB_LOAD_32_IMMEDIATE(&(node->__next), 0);
     node->__filter = (ULONG) __MCF_seh_top;
     __MCF_TEB_STORE_32_IMMEDIATE(0, node);


### PR DESCRIPTION
This does similar stuff to c135d9832115b3ee08c6754fd345d951abbdb961, but only for the DLL. For the static library we have to keep `.safeseh`.