### PR TITLE
build: Avoid command-line options that start with `/`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,7 +199,7 @@ mcfgthread_version_o = import('windows').compile_resources(
       args: [ '-I.', '-c65001' ],
       depend_files: [ 'mcfgthread/version.h.in', 'mcfgthread/version.manifest' ])
 
-if cc.has_link_argument('/LTCG')
+if cc.has_link_argument('-LTCG')
   lib_mcfgthread_dll_link_args = [
         '-Wl,-nodefaultlib', '-Wl,-dynamicbase', '-Wl,-nxcompat', '-Wl,-opt:ref',
         '-Wl,-opt:icf', '-Xlinker', '-subsystem:windows,6.1', '-Wl,-kill-at',


### PR DESCRIPTION
This will confuse the MSYS2 meson.