### PR TITLE
gthr_aux: Ensure function calls to x86-64 code go through call checker

### DIFF
--- a/mcfgthread/gthr_aux.c
+++ b/mcfgthread/gthr_aux.c
@@ -154,6 +154,15 @@ __asm__ (
 /* Stash `once` for the handler.  */
 "  str x0, [sp, 16]  \n"
 /* Make the call `(*init_proc) (arg)`.  */
+#  if defined __arm64ec__
+"  adrp x9, __os_arm64x_check_icall  \n"
+"  ldr x9, [x9, :lo12:__os_arm64x_check_icall]  \n"
+"  adrp x10, __MCF_arm64ec_exit_thunk_void  \n"
+"  add x10, x10, :lo12:__MCF_arm64ec_exit_thunk_void  \n"
+"  mov x11, x1  \n"
+"  blr x9  \n"
+"  mov x1, x11  \n"
+#  endif
 "  mov x0, x2  \n"
 "  blr x1  \n"
 /* Disarm the once flag with a tail call.  */

--- a/mcfgthread/xglobals.c
+++ b/mcfgthread/xglobals.c
@@ -497,9 +497,10 @@ __asm__ (
 ".globl __os_arm64x_helper8  \n"
 "__os_arm64x_helper8:  \n"
 "  .quad 0  \n"
-/* This is the ARM64EC Adjustor Thunk.  */
 ".text  \n"
 "  .p2align 2  \n"
+/* This is the ARM64EC Adjustor Thunk. Calls to this function are synthesized
+ * by the compiler.  */
 ".globl __icall_helper_arm64ec  \n"
 ".def __icall_helper_arm64ec; .scl 2; .type 32; .endef  \n"
 "__icall_helper_arm64ec:  \n"
@@ -517,6 +518,25 @@ __asm__ (
 ".seh_save_fplr_x 16  \n"
 ".seh_endepilogue  \n"
 "  br x11  \n"
+".seh_endproc  \n"
+/* This is a common Exit Thunk for functions that return void.  */
+".globl __MCF_arm64ec_exit_thunk_void  \n"
+".def __MCF_arm64ec_exit_thunk_void; .scl 2; .type 32; .endef  \n"
+"__MCF_arm64ec_exit_thunk_void:  \n"
+".seh_proc __MCF_arm64ec_exit_thunk_void  \n"
+"  stp fp, lr, [sp, -48]!  \n"
+".seh_save_fplr_x 48  \n"
+"  mov fp, sp  \n"
+".seh_set_fp  \n"
+".seh_endprologue  \n"
+"  adrp x16, __os_arm64x_dispatch_call_no_redirect  \n"
+"  ldr x16, [x16, :lo12:__os_arm64x_dispatch_call_no_redirect]  \n"
+"  blr x16  \n"
+".seh_startepilogue  \n"
+"  ldp fp, lr, [sp], 48  \n"
+".seh_save_fplr_x 48  \n"
+".seh_endepilogue  \n"
+"  ret  \n"
 ".seh_endproc  \n"
 );
 #endif


### PR DESCRIPTION
Reference: https://learn.microsoft.com/en-us/windows/arm/arm64ec-abi?source=recommendations#call-checkers