### PR TITLE
mutex: Do not update spinning failure counter at first attempt

### DIFF
--- a/mcfgthread/mutex.c
+++ b/mcfgthread/mutex.c
@@ -61,9 +61,8 @@ _MCF_mutex_lock_slow(_MCF_mutex* mutex, const int64_t* timeout_opt)
      * is less than the number bits in `__sp_nfail` and `__sp_nfail` is less
      * than `__MCF_MUTEX_SP_NFAIL_THRESHOLD`, which means the current thread
      * is allowed to spin, allocate a spinning bit; otherwise, allocate a
-     * sleeping count. The spinning failure counter is decremented if the
-     * mutex can be locked immediately; and incremented otherwise, no matter
-     * whether the current thread is going to spin or not.  */
+     * sleeping count. The spinning failure counter is usually not updated;
+     * but if we won't do a spinning attempt, it should be incremented anyway.  */
   try_lock_loop:
     _MCF_atomic_load_pptr_rlx(&old, mutex);
     for(;;) {
@@ -75,7 +74,7 @@ _MCF_mutex_lock_slow(_MCF_mutex* mutex, const int64_t* timeout_opt)
 #pragma GCC diagnostic warning "-Wsign-conversion"
       new.__locked = 1;
       new.__sp_mask = old.__sp_mask | (old.__sp_mask + should_spin);
-      new.__sp_nfail = do_adjust_sp_nfail(old.__sp_nfail, (int) old.__locked * 2 - 1);
+      new.__sp_nfail = do_adjust_sp_nfail(old.__sp_nfail, should_sleep);
       new.__nsleep = old.__nsleep + should_sleep;
 #pragma GCC diagnostic pop
 
@@ -133,7 +132,7 @@ _MCF_mutex_lock_slow(_MCF_mutex* mutex, const int64_t* timeout_opt)
 #pragma GCC diagnostic ignored "-Wconversion"
         new.__locked = 1;
         new.__sp_mask = old.__sp_mask & ~lmask;
-        new.__sp_nfail = do_adjust_sp_nfail(old.__sp_nfail, (int) old.__locked - 1);
+        new.__sp_nfail = do_adjust_sp_nfail(old.__sp_nfail, (int) old.__locked * 2 - 1);
         new.__nsleep = old.__nsleep + old.__locked;
 #pragma GCC diagnostic pop
 

--- a/test/mutex_spin_fail.c
+++ b/test/mutex_spin_fail.c
@@ -18,6 +18,7 @@ main(void)
     assert(mutex.__sp_mask == 0);
     assert(mutex.__sp_nfail == 0);
 
+    fprintf(stderr, "try succeeding: fast\n");
     assert(_MCF_mutex_lock(&mutex, (const int64_t[]){ -100 }) == 0);
     assert(mutex.__locked == 1);
     assert(mutex.__sp_nfail == 0);
@@ -34,17 +35,18 @@ main(void)
     assert(mutex.__locked == 1);
     assert(mutex.__sp_nfail == 15);
 
-    for(size_t count = 15;  count >= 1;  --count) {
-      fprintf(stderr, "try succeeding: %d\n", (int) count);
-      _MCF_mutex_unlock(&mutex);
-      assert(mutex.__locked == 0);
-      assert(_MCF_mutex_lock(&mutex, (const int64_t[]){ -100 >> count }) == 0);
-      assert(mutex.__sp_nfail == count - 1);
-    }
-
-    fprintf(stderr, "try succeeding: final\n");
+    fprintf(stderr, "try succeeding: fast\n");
     _MCF_mutex_unlock(&mutex);
     assert(mutex.__locked == 0);
     assert(_MCF_mutex_lock(&mutex, (const int64_t[]){ -100 }) == 0);
-    assert(mutex.__sp_nfail == 0);
+    assert(mutex.__sp_nfail == 15);
+
+    // TODO: Need to figure how to test spin success.
+    // for(size_t count = 15;  count >= 1;  --count) {
+    //   fprintf(stderr, "try succeeding: %d\n", (int) count);
+    //   _MCF_mutex_unlock(&mutex);
+    //   assert(mutex.__locked == 0);
+    //   assert(_MCF_mutex_lock(&mutex, (const int64_t[]){ -100 }) == 0);
+    //   assert(mutex.__sp_nfail == count - 1);
+    // }
   }


### PR DESCRIPTION
In a single-thread process, spinning attempts always fail. Just because a
mutex can be grabbed at first attempt doesn't mean later spinning attempts
will succeed. Under such circumstances the spinning counter should not be
updated.