### PR TITLE
mutex: Update management of spin failure counter

### DIFF
--- a/mcfgthread/mutex.c
+++ b/mcfgthread/mutex.c
@@ -58,9 +58,9 @@ _MCF_mutex_lock_slow(_MCF_mutex* mutex, const int64_t* timeout_opt)
     _MCF_mutex old, new;
 
     /* If this mutex has not been locked, lock it; otherwise, if `__sp_mask`
-     * is less than the number bits in `__sp_nfail` and `__sp_nfail` is less
-     * than `__MCF_MUTEX_SP_NFAIL_THRESHOLD`, which means the current thread
-     * is allowed to spin, allocate a spinning bit; otherwise, allocate a
+     * contains at least one zero bit and `__sp_nfail` is less than
+     * `__MCF_MUTEX_SP_NFAIL_THRESHOLD`, which means the current thread is
+     * allowed to spin, allocate a spinning bit; otherwise, allocate a
      * sleeping count. The spinning failure counter is decremented if the
      * mutex can be locked immediately.  */
   try_lock_loop:


### PR DESCRIPTION
Old rules:

1. If a thread grabbed the mutex on first attempt, `__sp_nfail` was decremented.
2. If a thread went to spin after first attempt, `__sp_nfail` was incremented temporarily, and: a) If it grabbed the mutex during spinning, `__sp_nfail` was decremented, so the eventual effect was that `__sp_nfail` was unchanged. b) If it failed and went to sleep, `__sp_nfail` was unchanged, so the eventual effect was that `__sp_nfail` was incremented.
3. If a thread went to sleep after first attempt, `__sp_nfail` was incremented.

New rules:

1. If a thread grabs the mutex on first attempt, `__sp_nfail` is decremented.
2. If a thread goes to spin after first attempt, and: a) If it grabs the mutex during spinning, `__sp_nfail` is decremented. b) If it fails and goes to sleep, `__sp_nfail` is incremented.
3. If a thread goes to sleep after first attempt, `__sp_nfail` is incremented.