### PR TITLE
clock: Add `_MCF_hires_tick_count()`

### DIFF
--- a/mcfgthread/clock.h
+++ b/mcfgthread/clock.h
@@ -50,6 +50,14 @@ _MCF_tick_count(void)
 
 __MCF_CLOCK_IMPORT
 double
+_MCF_hires_tick_count(void)
+  __MCF_noexcept;
+
+/* Gets the value of the performance counter on the current platform. This is
+ * the traditional high-resolution clock for measurement, but it may deviate
+ * from `_MCF_hires_tick_count()` by a few milliseconds.  */
+__MCF_CLOCK_IMPORT
+double
 _MCF_perf_counter(void)
   __MCF_noexcept;
 

--- a/mcfgthread/src/clock.c
+++ b/mcfgthread/src/clock.c
@@ -87,13 +87,19 @@ _MCF_hires_steady_now(void)
     return (double)(int64_t) ull * 0.0001;
   }
 
-__MCF_DLLEXPORT
-int64_t
-_MCF_tick_count(void)
+static inline
+void
+do_QueryInterruptTime(ULONGLONG* outp)
   {
-    char* pSharedInterruptTime = (char*) (__MCF_SHARED_USER_DATA_VA + 0x08);
+    /* At address `0x7FFE0000` (`MM_SHARED_USER_DATA_VA` in Windows SDK for
+     * assembly, same on all architectures) there's a read-only structure of
+     * type `KUSER_SHARED_DATA`. The `InterruptTime` field is at offset `8` on
+     * all architectures; see
+     * <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-kuser_shared_data>.  */
+    volatile char* shared_user_data = (char*) 0x7FFE0000;
+    __asm__ ("" : "+r"(shared_user_data));  /* workaround for optimizer bug  */
 #if __MCF_64_32(1, 0)
-    return (int64_t) do_divide_by_10000(*(const volatile ULONGLONG*) pSharedInterruptTime);
+    *outp = *(volatile ULONGLONG*) (shared_user_data + 8);
 #else
     ULONG high, low;
     do {
@@ -102,11 +108,39 @@ _MCF_tick_count(void)
        * `LowPart` then `High1Time` so we read them in the reverse order. If
        * `High1Time` does not equal `High2Time`, then the value will have
        * been split and we must try again.  */
-      high = *(const volatile ULONG*) (pSharedInterruptTime + 0x04);
-      low = *(const volatile ULONG*) (pSharedInterruptTime + 0x00);
-    } while(high != *(const volatile ULONG*) (pSharedInterruptTime + 0x08));
-    return (int64_t) do_divide_by_10000(high * 0x100000000ULL + low);
+      high = *(volatile ULONG*) (shared_user_data + 12);
+      low = *(volatile ULONG*) (shared_user_data + 8);
+    } while(high != *(volatile ULONG*) (shared_user_data + 16));
+    *outp = (ULONGLONG) high << 32 | low;
 #endif
+  }
+
+
+__MCF_DLLEXPORT
+int64_t
+_MCF_tick_count(void)
+  {
+    /* The interrupt-time count is more precise than `GetTickCount64()`.  */
+    ULONGLONG ull;
+    do_QueryInterruptTime(&ull);
+    return (int64_t) do_divide_by_10000(ull);
+  }
+
+__MCF_DLLEXPORT
+double
+_MCF_hires_tick_count(void)
+  {
+    if(__MCF_HAS_G_IMP(QueryInterruptTimePrecise)) {
+      /* This is available since Windows 10.  */
+      ULONGLONG ull;
+      __MCF_G_IMP(QueryInterruptTimePrecise) (&ull);
+      return (double)(int64_t) ull * 0.0001;
+    }
+
+    /* The interrupt-time count is more precise than `GetTickCount64()`.  */
+    ULONGLONG ull;
+    do_QueryInterruptTime(&ull);
+    return (double)(int64_t) ull * 0.0001;
   }
 
 __MCF_DLLEXPORT

--- a/mcfgthread/src/xglobals.c
+++ b/mcfgthread/src/xglobals.c
@@ -449,6 +449,12 @@ __MCF_gthread_initialize_globals(void)
     dll_fn = GetProcAddress(__MCF_crt_kernelbase, "QueryUnbiasedInterruptTimePrecise");
     __MCF_G(imp_QueryUnbiasedInterruptTimePrecise) = (void*) dll_fn;
 
+    /* This function is available since Windows 10. Microsoft documentation says
+     * this is exported from KERNEL32.DLL, but it's really only exported from
+     * KERNELBASE.DLL.  */
+    dll_fn = GetProcAddress(__MCF_crt_kernelbase, "QueryInterruptTimePrecise");
+    __MCF_G(imp_QueryInterruptTimePrecise) = (void*) dll_fn;
+
     /* Attach the main thread and make it joinable. The structure should
      * be all zeroes so no initialization is necessary.  */
     __MCF_thread_attach_foreign(__MCF_G(main_thread));

--- a/mcfgthread/src/xglobals.h
+++ b/mcfgthread/src/xglobals.h
@@ -28,12 +28,6 @@
 #  define nullptr   ((void*) __MCF_IPTR_0)
 #endif
 
-/* Define a value that resembles `MM_SHARED_USER_DATA_VA` in Windows SDK for
- * assembly, which has the same value on all architectures. This points to a
- * read-only structure of type `KUSER_SHARED_DATA`; see
- * <https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddk/ns-ntddk-kuser_shared_data>.  */
-#define __MCF_SHARED_USER_DATA_VA  0x7FFE0000U
-
 /* Define data that must be placed in `.rdata` despite `-fdata-sections`.  */
 #define __MCF_CRT_RDATA  __attribute__((__used__, __section__(".rdata")))
 #define __MCF_CRT_XL(x)  __attribute__((__used__, __section__(".CRT$XL" #x)))
@@ -61,6 +55,7 @@
 typedef void __stdcall typeof_GetSystemTimePreciseAsFileTime(FILETIME*);
 typedef void __stdcall typeof_QueryInterruptTime(ULONGLONG*);
 typedef void __stdcall typeof_QueryUnbiasedInterruptTimePrecise(ULONGLONG*);
+typedef void __stdcall typeof_QueryInterruptTimePrecise(ULONGLONG*);
 typedef LPVOID __stdcall typeof_TlsGetValue2(ULONG);
 
 /* Terminates the current process. This function is used as the exception
@@ -296,6 +291,7 @@ struct __MCF_crt_xglobals
     __MCF_BR(_MCF_mutex) thread_oom_mtx;  /* v1.9 */
     __MCF_thread_base opt_thread_oom_self_st;  /* v1.9 */
     typeof_QueryUnbiasedInterruptTimePrecise* imp_QueryUnbiasedInterruptTimePrecise;  /* v2.4 */
+    typeof_QueryInterruptTimePrecise* imp_QueryInterruptTimePrecise;  /* v2.4 */
   };
 
 /* This is a pointer to the process-specific named shared memory in the
@@ -330,6 +326,7 @@ __MCF_STATIC_ASSERT(__MCF_OFFXG_(imp_QueryInterruptTime) == __MCF_64_32(6800, 44
 __MCF_STATIC_ASSERT(__MCF_OFFXG_(thread_oom_mtx) == __MCF_64_32(6808, 4428));
 __MCF_STATIC_ASSERT(__MCF_OFFXG_(opt_thread_oom_self_st) == __MCF_64_32(6816, 4432));
 __MCF_STATIC_ASSERT(__MCF_OFFXG_(imp_QueryUnbiasedInterruptTimePrecise) == __MCF_64_32(8416, 5232));
+__MCF_STATIC_ASSERT(__MCF_OFFXG_(imp_QueryInterruptTimePrecise) == __MCF_64_32(8424, 5236));
 
 /* Define inline functions after all declarations.
  * We would like to keep them away from declarations for conciseness, which also

--- a/test/optional_imports.c
+++ b/test/optional_imports.c
@@ -37,6 +37,11 @@ main(void)
     fprintf(stderr, "QueryInterruptTime = %p\n", fn);
     assert(fn == (void*) GetProcAddress(kernelbase, "QueryInterruptTime"));
 
+    // https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryinterrupttimeprecise
+    fn = (void*) __MCF_G_IMP_OPT(QueryInterruptTimePrecise);
+    fprintf(stderr, "QueryInterruptTimePrecise = %p\n", fn);
+    assert(fn == (void*) GetProcAddress(kernelbase, "QueryInterruptTimePrecise"));
+
     // https://learn.microsoft.com/en-us/windows/win32/api/realtimeapiset/nf-realtimeapiset-queryunbiasedinterrupttimeprecise
     fn = (void*) __MCF_G_IMP_OPT(QueryUnbiasedInterruptTimePrecise);
     fprintf(stderr, "QueryUnbiasedInterruptTimePrecise = %p\n", fn);

--- a/test/tick_count.c
+++ b/test/tick_count.c
@@ -16,12 +16,21 @@ main(void)
   {
     SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
 
-    for(uint32_t i = 0;  i < 300;  i++) {
+    for(uint32_t i = 0;  i < 200;  i++) {
       Sleep(10);
       ULONGLONG t1 = GetTickCount64();
       ULONGLONG t2 = (ULONGLONG) _MCF_tick_count();
 
       assert(t1 <= t2);
-      assert(t2 - t1 <= 20000);
+      assert(t2 - t1 <= 100);
+    }
+
+    for(uint32_t i = 0;  i < 200;  i++) {
+      Sleep(10);
+      ULONGLONG t1 = (ULONGLONG) _MCF_tick_count();
+      ULONGLONG t2 = (ULONGLONG) _MCF_hires_tick_count();
+
+      assert(t1 <= t2);
+      assert(t2 - t1 <= 10);
     }
   }


### PR DESCRIPTION
This returns a more precise value of the interrupt time, which isn't identical to the performance counter.