### PR TITLE
mutex: Delay lock acquisition in spin loop

### DIFF
--- a/mcfgthread/mutex.h
+++ b/mcfgthread/mutex.h
@@ -31,12 +31,6 @@ struct __MCF_mutex
  * value of `__sp_nfail`, and must not be zero.  */
 #define __MCF_MUTEX_SP_NFAIL_THRESHOLD   10U
 
-/* This is the initial number of iterations that a thread may spin before it
- * goes to sleep. As spinning starts to fail more frequently, later threads
- * spin fewer times, until the number drops to zero. This value had better be
- * divisible by `__MCF_MUTEX_SP_NFAIL_THRESHOLD`.  */
-#define __MCF_MUTEX_MAX_SPIN_COUNT     1280U
-
 /* Initializes a mutex dynamically. Static ones should be initialized with
  * `{0}`, like other structs.  */
 __MCF_MUTEX_INLINE

--- a/mcfgthread/src/mutex.c
+++ b/mcfgthread/src/mutex.c
@@ -106,12 +106,11 @@ _MCF_mutex_lock_slow(_MCF_mutex* mtx, const int64_t* timeout_opt)
     if(sp_budget > 0) {
       uint32_t my_mask = (uint32_t) (old.__sp_mask ^ new.__sp_mask);
       __MCF_ASSERT(my_mask != 0);
-      uint32_t restore_mask = my_mask;
 
-      uint32_t sp_rem = sp_budget * (__MCF_MUTEX_MAX_SPIN_COUNT / __MCF_MUTEX_SP_NFAIL_THRESHOLD);
-      while(sp_rem > 0) {
-        sp_rem --;
-        YieldProcessor();
+      while(sp_budget > 0) {
+        sp_budget --;
+        for(uint32_t sp_scale = 160;  sp_scale != 0;  sp_scale --)
+          YieldProcessor();
 
         /* Wait for my turn. It's the simplest and fastest way to perform
          * just an atomic exchange, on both x86 and ARM.  */
@@ -134,17 +133,15 @@ _MCF_mutex_lock_slow(_MCF_mutex* mtx, const int64_t* timeout_opt)
               return 0;
           }
           else {
-            /* The mutex is stolen, so continue spinning. We used to restore
-             * `my_mask` in `__sp_mask`, but this caused serious performance
-             * regression. Now the current thread just continues spinning
-             * until another thread reallocates `my_mask`, or it runs out of
-             * `sp_rem`.  */
-            break;
-          }
+            /* The mutex is stolen, so restore my mask and continue spinning.  */
+            new.__locked = 1;
+            new.__sp_mask = (old.__sp_mask | my_mask) & 0x0FU;
+            new.__sp_nfail = old.__sp_nfail;
+            new.__nsleep = old.__nsleep;
 
-        /* The mask has been consumed by the waker and may be allocated by
-         * another thread, so don't restore it any more.  */
-        restore_mask = 0;
+            if(_MCF_atomic_cmpxchg_weak_pptr_rlx(mtx, &old, &new))
+              break;
+          }
       }
 
       /* We have wasted some time, so return the spinning mask and allocate
@@ -157,7 +154,7 @@ _MCF_mutex_lock_slow(_MCF_mutex* mtx, const int64_t* timeout_opt)
       for(;;)
         if(old.__locked == 0) {
           new.__locked = 1;
-          new.__sp_mask = (old.__sp_mask & (0x0FU - restore_mask)) & 0x0FU;
+          new.__sp_mask = old.__sp_mask;
           new.__sp_nfail = do_adjust_sp_nfail(old.__sp_nfail, -1) & 0x0FU;
           new.__nsleep = old.__nsleep;
 
@@ -166,7 +163,7 @@ _MCF_mutex_lock_slow(_MCF_mutex* mtx, const int64_t* timeout_opt)
         }
         else {
           new.__locked = 1;
-          new.__sp_mask = (old.__sp_mask & (0x0FU - restore_mask)) & 0x0FU;
+          new.__sp_mask = old.__sp_mask;
           new.__sp_nfail = do_adjust_sp_nfail(old.__sp_nfail, +1) & 0x0FU;
           new.__nsleep = (old.__nsleep + 1U) & (__MCF_UINTPTR_MAX >> 9);
 


### PR DESCRIPTION
This is the correct fix for what was reverted in
338e6d2d2a50316af056a8245101e948aa8431ca.

For a spinning thread, if the lock was stolen by another thread, its bit in `__sp_mask`, which had been cleared by the awaker, was not restored, so the thread got stuck in the spin loop until it ran out of iterations.

The bit shall be restored if the thread cannot grab the lock and returns to spin. However, in order to decrease contention on the mutex, it should only come back to look at the mutex 'long enough' after a notification is received.