### PR TITLE
thread: Fix race condition in initialization

### DIFF
--- a/mcfgthread/src/thread.c
+++ b/mcfgthread/src/thread.c
@@ -97,7 +97,7 @@ _MCF_thread_new_aligned(_MCF_thread_procedure* proc, size_t align, const void* d
     _MCF_atomic_store_32_rlx(thrd->__nref, 2);
     thrd->__proc = proc;
     thrd->__handle = CreateThread(nullptr, 0, do_win32_thread_routine, thrd, 0,
-                                  (void*) &(thrd->__tid));
+                                  (DWORD*) &(thrd->__tid));
     if(!thrd->__handle) {
       __MCF_mfree_nonnull(thrd);
       return nullptr;
@@ -113,7 +113,7 @@ __MCF_thread_attach_foreign(_MCF_thread* thrd)
   {
     __MCF_ASSERT(thrd->__nref[0] == 0);
     __MCF_ASSERT(thrd->__tid == 0);
-    __MCF_ASSERT(thrd->__handle == nullptr);
+    __MCF_ASSERT(thrd->__handle == NULL);
 
     /* Initialize thread identity fields.  */
     thrd->__tid = __MCF_tid();

--- a/mcfgthread/src/thread.c
+++ b/mcfgthread/src/thread.c
@@ -8,16 +8,29 @@
 #include "xprecompiled.h"
 #define __MCF_THREAD_IMPORT  __MCF_DLLEXPORT
 #define __MCF_THREAD_INLINE  __MCF_DLLEXPORT
+#define __MCF_THREAD_DETAILS  1
 #include "../thread.h"
 #include "xglobals.h"
+
+enum
+  {
+    init_st_zero     = 0,
+    init_st_success  = 1,
+  };
 
 static __MCF_REALIGN_SP
 void
 do_thread_startup(_MCF_thread* thrd)
   {
     __MCF_USING_SEH_TERMINUS;
-    thrd->__tid = __MCF_tid();
+    if(_MCF_event_await_change(thrd->__init_done, init_st_zero, nullptr) != init_st_success)
+      return;
+
+    __MCF_ASSERT(thrd->__tid != 0);
+    __MCF_ASSERT(thrd->__handle != NULL);
+    thrd->__libobjc_tls_data = nullptr;
     __MCF_CHECK(TlsSetValue(__MCF_G(tls_index), thrd));
+
 #if defined __MCF_M_X86_ASM
     /* Set x87 precision to 64-bit mantissa (GNU `long double` format).  */
     __asm__ volatile ("fninit");
@@ -93,7 +106,8 @@ _MCF_thread_new_aligned(_MCF_thread_procedure* proc, size_t align, const void* d
         __MCF_mcopy(thrd->__data_opt, data_opt, size);
     }
 
-    /* Create a thread and wait for its initialization to finish.  */
+    /* Create a thread, which shall wait on `__init_done` and shall not continue
+     * before `__tid` and `__handle` are initialized.  */
     _MCF_atomic_store_32_rlx(thrd->__nref, 2);
     thrd->__proc = proc;
     thrd->__handle = CreateThread(nullptr, 0, do_win32_thread_routine, thrd, 0,
@@ -104,6 +118,7 @@ _MCF_thread_new_aligned(_MCF_thread_procedure* proc, size_t align, const void* d
     }
 
     /* Return the initialized thread.  */
+    _MCF_event_set(thrd->__init_done, init_st_success);
     return thrd;
   }
 

--- a/mcfgthread/thread.h
+++ b/mcfgthread/thread.h
@@ -13,6 +13,9 @@
 #include "tls.h"
 #include "atomic.h"
 #include "teb.h"
+#ifdef __MCF_THREAD_DETAILS
+#include "event.h"
+#endif
 
 __MCF_CXX(extern "C" {)
 #ifndef __MCF_THREAD_IMPORT
@@ -33,7 +36,14 @@ struct __MCF_thread_base
     __MCF_BR(__MCF_dtor_queue) __atexit_queue;  /* for `__cxa_thread_atexit()`  */
     __MCF_BR(__MCF_tls_table) __tls_table;  /* for `_MCF_tls_get()` and `_MCF_tls_set()`  */
 
-    void* __libobjc_tls_data;  /* for GCC libobjc  */
+#ifdef __MCF_THREAD_DETAILS
+    union {
+#endif
+      void* __libobjc_tls_data;  /* for GCC libobjc  */
+#ifdef __MCF_THREAD_DETAILS
+      __MCF_BR(_MCF_event) __init_done;
+    };
+#endif
   };
 
 /* This is the default alignment of user-defined data that is guaranteed by


### PR DESCRIPTION
ca3396fb9c24fe065dd2f6690c0d668691e091ff removed the initialization protocol.
There were idempotant writes to ensure `__tid` have a correct value before the
user-defined thread procedure, but `__handle` was left unsynchronized between
the new thread and the caller.

The fix is to make the new thread wait for the creator. The creator will not
wait for the new thread; if `_MCF_thread_new()` is called in `DllMain()`, it
would deadlock.